### PR TITLE
[Openapispec] Make operationId unique

### DIFF
--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 7, 4)
+VERSION = (0, 7, 5)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -349,7 +349,7 @@ class OpenApiSpec:
             "protocol": "h2",
             "path_translation": "APPEND_PATH_TO_ADDRESS",
         }
-        method_spec["operationId"] = entry.function_name
+        method_spec["operationId"] = f"{entry.method.lower()}_{entry.function_name}"
 
         params = []
         type_hints = get_type_hints(entry.route_function)

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -25,7 +25,7 @@ class TestOpenApiSpec:
                         "protocol": "h2",
                         "path_translation": "APPEND_PATH_TO_ADDRESS",
                     },
-                    "operationId": "route",
+                    "operationId": "get_route",
                     "responses": {"200": {"description": "A successful response"}},
                 }
             }


### PR DESCRIPTION
Makes operationId's unique per method. (closes #183 )

`"operationId": "get_function_name",`
`"operationId": "post_function_name",`