### PR TITLE
[OpenAPI] openapi  -v 3 option 

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -508,7 +508,7 @@ OpenApi Spec
 
 Goblet generates an `OpenApi`_ spec from your route endpoints in order to create the api gateway. The open api spec is written to the 
 ``.goblet`` folder and can be used for other tools. To generate just the open api spec you can run the command ``goblet openapi FUNCTION_NAME``.
-Note that gcp `gateway`_ only supports openapi spec 2.0. 
+Note that gcp `gateway`_ only supports openapi spec 2.0. You can additionally generate a 3.0.1 version of the spec by running ``goblet openapi FUNCTION_NAME -v 3``. 
 
 
 By default the param types will be created in the spec as strings and a base 200 response. 


### PR DESCRIPTION
Added option to select --version 3 to also create an openapi 3.0.1 spec (closes #185 ). 
`
goblet openapi FUNCTION -v 3
`

this returns in `.goblet/config.json`

```
FUNCTION_NAME_openapi_spec.yml
FUNCTION_NAME_openapi_spec_3.yml
```