### PR TITLE
Add preflight cors support

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -712,6 +712,8 @@ Use the `CORSConfig` class to set customized cors headers from the `goblet.resou
     def custom_cors():
         return jsonify('localhost is allowed')
 
+Setting cors on an endpoint or the application will automatically add an OPTIONS method to support preflighting requests. 
+
 Multiple Cloudfunctions
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -63,7 +63,9 @@ class ApiGateway(Handler):
             kwargs["cors"] = self.cors
         path_entries = self.resources.get(path, {})
         if kwargs["cors"] and "OPTIONS" in methods:
-             raise ValueError("Route entry cannot have both cors=True and methods=['OPTIONS', ...] configured.")
+            raise ValueError(
+                "Route entry cannot have both cors=True and methods=['OPTIONS', ...] configured."
+            )
         for method in methods:
             if path_entries.get(method):
                 raise ValueError(
@@ -77,8 +79,8 @@ class ApiGateway(Handler):
             path_entries[method] = entry
         # Add OPTIONS if cors set
         if kwargs["cors"]:
-            entry = RouteEntry(handle_cors_options, name, path, 'OPTIONS', **kwargs)
-            path_entries['OPTIONS'] = entry
+            entry = RouteEntry(handle_cors_options, name, path, "OPTIONS", **kwargs)
+            path_entries["OPTIONS"] = entry
         self.resources[path] = path_entries
 
     def __call__(self, request, context=None):
@@ -570,6 +572,7 @@ class CORSConfig(object):
                 self.get_access_control_headers() == other.get_access_control_headers()
             )
         return False
+
 
 def handle_cors_options():
     """Return 200"""

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -62,6 +62,8 @@ class ApiGateway(Handler):
         if not kwargs.get("cors"):
             kwargs["cors"] = self.cors
         path_entries = self.resources.get(path, {})
+        if kwargs["cors"] and "OPTIONS" in methods:
+             raise ValueError("Route entry cannot have both cors=True and methods=['OPTIONS', ...] configured.")
         for method in methods:
             if path_entries.get(method):
                 raise ValueError(
@@ -73,6 +75,10 @@ class ApiGateway(Handler):
                 )
             entry = RouteEntry(func, name, path, method, **kwargs)
             path_entries[method] = entry
+        # Add OPTIONS if cors set
+        if kwargs["cors"]:
+            entry = RouteEntry(handle_cors_options, name, path, 'OPTIONS', **kwargs)
+            path_entries['OPTIONS'] = entry
         self.resources[path] = path_entries
 
     def __call__(self, request, context=None):
@@ -80,11 +86,10 @@ class ApiGateway(Handler):
         path = request.path
         entry = self.resources.get(path, {}).get(method)
         if not entry:
-            # test param paths
+            # search param paths "/{PARAM}"
             for p in self.resources:
                 if "{" in p and self._matched_path(p, path):
                     entry = self.resources.get(p, {}).get(method)
-        # TODO: better handling
         if not entry:
             raise ValueError(f"No route found for {path} with {method}")
         return entry(request)
@@ -565,3 +570,7 @@ class CORSConfig(object):
                 self.get_access_control_headers() == other.get_access_control_headers()
             )
         return False
+
+def handle_cors_options():
+    """Return 200"""
+    return "success"

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -160,6 +160,22 @@ class TestRoutes:
         resp3 = app(mock_event3, None)
         assert resp3[2]["Access-Control-Allow-Origin"] == "localhost"
 
+    def test_cors_options(self):
+        app = Goblet(function_name="goblet_cors")
+
+        @app.route("/test", cors=True)
+        def mock_function():
+            return "200"
+
+        mock_event1 = Mock()
+        mock_event1.path = "/test"
+        mock_event1.method = "OPTIONS"
+        mock_event1.headers = {}
+        mock_event1.json = {}
+        resp = app(mock_event1, None)
+        assert resp.body == "success"
+        assert resp.status_code == 200
+
     def test_deploy_routes(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
         monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")


### PR DESCRIPTION
Setting cors on an endpoint or the application will automatically add an OPTIONS method to support preflighting requests. 