### PR TITLE
Removed unused CMD

### DIFF
--- a/goblet/write_files.py
+++ b/goblet/write_files.py
@@ -70,8 +70,5 @@ COPY . .
 
 # Install dependencies.
 RUN pip install -r requirements.txt
-
-# Run the web service on container startup.
-CMD exec functions-framework --target=goblet_entrypoint
 """
         )


### PR DESCRIPTION
The CMD in the dockerfile isn't used, so to improve clarity, I think it should be removed. This argument instead is being used.

https://github.com/goblet/goblet/blob/bec9e85dcb66a13834aada9a4d4b99772494f947/goblet/deploy.py#L151