### PR TITLE
Include timezone as a schedule argument

### DIFF
--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -76,7 +76,11 @@ class DecoratorAPI:
         """Scheduler job Http trigger"""
         return self._create_registration_function(
             handler_type="schedule",
-            registration_kwargs={"schedule": schedule, "timezone": timezone, "kwargs": kwargs},
+            registration_kwargs={
+                "schedule": schedule,
+                "timezone": timezone,
+                "kwargs": kwargs,
+            },
         )
 
     def topic(self, topic, **kwargs):

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -72,11 +72,11 @@ class DecoratorAPI:
             registration_kwargs={"path": path, "methods": methods, "kwargs": kwargs},
         )
 
-    def schedule(self, schedule, **kwargs):
+    def schedule(self, schedule, timezone = "UTC", **kwargs):
         """Scheduler job Http trigger"""
         return self._create_registration_function(
             handler_type="schedule",
-            registration_kwargs={"schedule": schedule, "kwargs": kwargs},
+            registration_kwargs={"schedule": schedule, "timezone": timezone, "kwargs": kwargs},
         )
 
     def topic(self, topic, **kwargs):

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -72,7 +72,7 @@ class DecoratorAPI:
             registration_kwargs={"path": path, "methods": methods, "kwargs": kwargs},
         )
 
-    def schedule(self, schedule, timezone = "UTC", **kwargs):
+    def schedule(self, schedule, timezone="UTC", **kwargs):
         """Scheduler job Http trigger"""
         return self._create_registration_function(
             handler_type="schedule",

--- a/goblet/resources/scheduler.py
+++ b/goblet/resources/scheduler.py
@@ -26,7 +26,7 @@ class Scheduler(Handler):
     def register_job(self, name, func, kwargs):
         schedule = kwargs["schedule"]
         kwargs = kwargs.pop("kwargs")
-        timezone = kwargs.get("timezone", "UTC")
+        timezone = kwargs["timezone"]
         description = kwargs.get("description", "Created by goblet")
         headers = kwargs.get("headers", {})
         httpMethod = kwargs.get("httpMethod", "GET")

--- a/goblet/resources/scheduler.py
+++ b/goblet/resources/scheduler.py
@@ -25,8 +25,8 @@ class Scheduler(Handler):
 
     def register_job(self, name, func, kwargs):
         schedule = kwargs["schedule"]
-        kwargs = kwargs.pop("kwargs")
         timezone = kwargs["timezone"]
+        kwargs = kwargs.pop("kwargs")
         description = kwargs.get("description", "Created by goblet")
         headers = kwargs.get("headers", {})
         httpMethod = kwargs.get("httpMethod", "GET")

--- a/goblet/tests/test_scheduler.py
+++ b/goblet/tests/test_scheduler.py
@@ -124,7 +124,9 @@ class TestScheduler:
         goblet_name = "goblet_example"
         scheduler = Scheduler(goblet_name)
         scheduler.register_job(
-            "test-job", None, kwargs={"schedule": "* * * * *", "kwargs": {}}
+            "test-job",
+            None,
+            kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
         )
         scheduler.deploy()
 
@@ -149,7 +151,9 @@ class TestScheduler:
         cloudrun_url = "https://goblet-12345.a.run.app"
         service_account = "SERVICE_ACCOUNT@developer.gserviceaccount.com"
         scheduler.register_job(
-            "test-job", None, kwargs={"schedule": "* * * * *", "kwargs": {}}
+            "test-job",
+            None,
+            kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
         )
         scheduler._deploy(config={"scheduler": {"serviceAccount": service_account}})
 
@@ -225,7 +229,9 @@ class TestScheduler:
         goblet_name = "goblet_example"
         scheduler = Scheduler(goblet_name)
         scheduler.register_job(
-            "test-job", None, kwargs={"schedule": "* * * * *", "kwargs": {}}
+            "test-job",
+            None,
+            kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
         )
         scheduler.destroy()
 
@@ -243,7 +249,9 @@ class TestScheduler:
         goblet_name = "goblet"
         scheduler = Scheduler(goblet_name)
         scheduler.register_job(
-            "scheduled_job", None, kwargs={"schedule": "* * * * *", "kwargs": {}}
+            "scheduled_job",
+            None,
+            kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
         )
         scheduler.sync(dryrun=True)
         scheduler.sync(dryrun=False)

--- a/goblet/tests/test_scheduler.py
+++ b/goblet/tests/test_scheduler.py
@@ -178,18 +178,25 @@ class TestScheduler:
         goblet_name = "goblet-test-schedule"
         scheduler = Scheduler(goblet_name)
         scheduler.register_job(
-            "test-job", None, kwargs={"schedule": "* * 1 * *", "kwargs": {}}
+            "test-job",
+            None,
+            kwargs={"schedule": "* * 1 * *", "timezone": "UTC", "kwargs": {}},
         )
         scheduler.register_job(
             "test-job",
             None,
-            kwargs={"schedule": "* * 2 * *", "kwargs": {"httpMethod": "POST"}},
+            kwargs={
+                "schedule": "* * 2 * *",
+                "timezone": "UTC",
+                "kwargs": {"httpMethod": "POST"},
+            },
         )
         scheduler.register_job(
             "test-job",
             None,
             kwargs={
                 "schedule": "* * 3 * *",
+                "timezone": "UTC",
                 "kwargs": {"headers": {"X-HEADER": "header"}},
             },
         )

--- a/goblet/write_files.py
+++ b/goblet/write_files.py
@@ -70,8 +70,5 @@ COPY . .
 
 # Install dependencies.
 RUN pip install -r requirements.txt
-
-# Run the web service on container startup.
-CMD exec functions-framework --target=goblet_entrypoint
 """
         )


### PR DESCRIPTION
Timezone is a pretty important part of any schedule - moving it to the function argument should make it clear how to do so.

I saw the kwargs, so I tried `timeZone` (what the API wants) and `time_zone` (what the python scheduler library wants). Had to go through the source code to find out it was `timezone`, so I hope this change makes things easier for other newcomers!