### PR TITLE
chore(Dockerfile): update python 3.7 -> 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-
 # https://hub.docker.com/_/python
-FROM python:3.7-slim
+FROM python:3.10-slim
 
-# Copy local code to the container image.
+# setup environment
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
 
 # Install dependencies.
+COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+COPY . .
 
 # Run the web service on container startup.
 CMD exec functions-framework --target=goblet_entrypoint

--- a/goblet/write_files.py
+++ b/goblet/write_files.py
@@ -60,15 +60,19 @@ To check out goblet documentation go to [docs](https://goblet.github.io/goblet/d
 def write_dockerfile():
     with open(f"{get_dir()}/Dockerfile", "w") as f:
         f.write(
-            """# https://hub.docker.com/_/python
-FROM python:3.7-slim
+            """\
+# https://hub.docker.com/_/python
+FROM python:3.10-slim
 
-# Copy local code to the container image.
+# setup environment
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
 
 # Install dependencies.
+COPY requirements.txt .
 RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+COPY . .
 """
         )


### PR DESCRIPTION
Updates the base container from `python:3.7-slim` to
`python:3.10-slim`

Also, installs the dependencies before copying the
application code to take advantage of docker build layer
caching.

Closes https://github.com/goblet/goblet/issues/205