### PR TITLE
[PubSub] pass through configuration for subscriptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Goblet Contributions
+
+To begin contributing to Goblet, make sure your Python Path is set within the top level of the directory by running: 
+
+```export PYTHONPATH=$(pwd)```

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You've now created your first app using goblet. You can make modifications to yo
 
 At this point, there are several next steps you can take.
 
-Docs - [Goblet Documentation](https://goblet.github.io/goblet/docs/build/html/index.html)
+Docs - [Goblet Documentation](https://goblet.github.io/goblet/build/html/index.html)
 
 If you're done experimenting with Goblet and you'd like to cleanup, you can use the `goblet destroy` command making sure to specify the desired location, and Goblet will delete all the resources it created when running the goblet deploy command.
 

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -160,6 +160,10 @@ provide an attribute dictionary which will only trigger the function if the pubs
 If using cloudrun backend or `use_subscription=true` the attributes will be created as a filter on the subscription itself. You can also pass in 
 a custom `filter` as well. Note that filters are not able to be modified once they are applied to a subscription. 
 
+In addition to filters you can also add configuration values that will be passed directly to the subscription. 
+By setting `config={"enableExactlyOnceDelivery": True}` you can enable exactly delivery to ensure messages are not redelivered once acknowledged.
+For additional information on configuration values available see `PubSub Subscription Fields <https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create#request-body>`
+
 Example usage:
 
 .. code:: python 

--- a/goblet/resources/pubsub.py
+++ b/goblet/resources/pubsub.py
@@ -139,7 +139,7 @@ class PubSub(Handler):
             "topic": f"projects/{topic['project']}/topics/{topic_name}",
             "filter": topic["filter"] or "",
             "pushConfig": {}
-            if topic["config"]["enableExactlyOnceDelivery"]
+            if topic["config"].get("enableExactlyOnceDelivery", None)
             else {
                 "pushEndpoint": push_url,
                 "oidcToken": {

--- a/goblet/resources/pubsub.py
+++ b/goblet/resources/pubsub.py
@@ -31,6 +31,7 @@ class PubSub(Handler):
         topic = kwargs["topic"]
         kwargs = kwargs.pop("kwargs")
         attributes = kwargs.get("attributes", {})
+        config = kwargs.get("config", {})
         filter = kwargs.get("filter")
         if not filter and attributes:
             filter = attributes_to_filter(attributes)
@@ -58,6 +59,7 @@ class PubSub(Handler):
                     "attributes": attributes,
                     "project": project,
                     "filter": filter,
+                    "config": config,
                 }
             }
 
@@ -136,13 +138,16 @@ class PubSub(Handler):
             "name": sub_name,
             "topic": f"projects/{topic['project']}/topics/{topic_name}",
             "filter": topic["filter"] or "",
-            "pushConfig": {
+            "pushConfig": {}
+            if topic["config"]["enableExactlyOnceDelivery"]
+            else {
                 "pushEndpoint": push_url,
                 "oidcToken": {
                     "serviceAccountEmail": service_account,
                     "audience": push_url,
                 },
             },
+            **topic["config"],
         }
         create_pubsub_subscription(
             client=self.versioned_clients.pubsub,

--- a/goblet/tests/data/http/pubsub-deploy-subscription-config/get-v1-projects-goblet-locations-us-central1-functions-goblet-topic-subscription-config_1.json
+++ b/goblet/tests/data/http/pubsub-deploy-subscription-config/get-v1-projects-goblet-locations-us-central1-functions-goblet-topic-subscription-config_1.json
@@ -1,0 +1,24 @@
+{
+  "headers": {},
+  "body": {
+    "name": "projects/goblet/locations/us-central1/functions/goblet-topic-subscription-config",
+    "description": "created by goblet",
+    "httpsTrigger": {
+      "url": "https://us-central1-goblet.cloudfunctions.net/goblet-topic-subscription-config",
+      "securityLevel": "SECURE_OPTIONAL"
+    },
+    "status": "ACTIVE",
+    "entryPoint": "goblet_entrypoint",
+    "timeout": "60s",
+    "availableMemoryMb": 256,
+    "serviceAccountEmail": "goblet@appspot.gserviceaccount.com",
+    "updateTime": "2022-08-04T16:04:52.724Z",
+    "versionId": "1",
+    "sourceUploadUrl": "https://storage.googleapis.com/uploads-915943219735.us-central1.cloudfunctions.appspot.com/20a48a3e-10be-442f-8d01-14120347434f.zip",
+    "runtime": "python37",
+    "ingressSettings": "ALLOW_ALL",
+    "buildId": "0d1472ef-efd7-4558-ae6a-7eabf950a91a",
+    "buildName": "projects/goblet/locations/us-central1/builds/0d1472ef-efd7-4558-ae6a-7eabf950a91a",
+    "dockerRegistry": "CONTAINER_REGISTRY"
+  }
+}

--- a/goblet/tests/data/http/pubsub-deploy-subscription-config/put-v1-projects-goblet-subscriptions-goblet-topic-subscription-config-test_1.json
+++ b/goblet/tests/data/http/pubsub-deploy-subscription-config/put-v1-projects-goblet-subscriptions-goblet-topic-subscription-config-test_1.json
@@ -1,0 +1,15 @@
+{
+  "headers": {},
+  "body": {
+    "name": "projects/goblet/subscriptions/goblet-topic-subscription-config-test",
+    "topic": "projects/goblet/topics/test",
+    "pushConfig": {},
+    "ackDeadlineSeconds": 60,
+    "messageRetentionDuration": "604800s",
+    "expirationPolicy": {
+      "ttl": "2678400s"
+    },
+    "enableExactlyOnceDelivery": true,
+    "state": "ACTIVE"
+  }
+}

--- a/goblet/tests/test_pubsub.py
+++ b/goblet/tests/test_pubsub.py
@@ -385,5 +385,5 @@ class TestPubSub:
             "put-v1-projects-goblet-subscriptions-goblet-topic-subscription-config-test_1.json",
         )
         responses = get_responses("pubsub-deploy-subscription-config")
-        assert put_subscription["body"]["enableExactlyOnceDelivery"] == True
+        assert put_subscription["body"]["enableExactlyOnceDelivery"]
         assert len(responses) == 2


### PR DESCRIPTION
- addresses https://github.com/goblet/goblet/issues/181
- allow pass through configuration for pubsub subscriptions
- note: need to ensure conflicting subscription config values are not set i.e, pushConfig or enableMessageOrdering and enableExactlyOnceDelivery cannot be set at the same time 