### PR TITLE
Fix custom files

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -124,7 +124,7 @@ For `Cloud Build configurations <https://cloud.google.com/build/docs/api/referen
         }
     }
 
-By default goblet includes all python files located in the directory. To include other files use the ``customFiles`` key
+By default goblet includes all python files located in the directory. To include other files use the ``custom_files`` key
 which takes in a list of python `glob`_ formatted strings.
 
 Example config.json: 
@@ -132,7 +132,10 @@ Example config.json:
 .. code:: json
 
     {
-        "customFiles": ["*.yaml"]
+        "custom_files": {
+            "include": ["*.yaml"],
+            "exclude": ["*.secret"]
+        }
     }   
 
 .. _GLOB: https://docs.python.org/3/library/glob.html

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -19,7 +19,7 @@ class Backend:
     resource_type = ""
     version = ""
 
-    def __init__(self, app, client, func_path, config={}, zip_config=None):
+    def __init__(self, app, client, func_path, config={}):
         self.app = app
         self.name = app.function_name
         self.log = logging.getLogger("goblet.backend")
@@ -29,9 +29,11 @@ class Backend:
         self.config = GConfig(config=config)
 
         # specifies which files to be zipped
-        self.zip_config = zip_config or {
-            "include": ["*.py"],
-            "exclude": ["build", "docs", "examples", "test", "tests", "venv"],
+        custom_files = self.config.custom_files or {}
+
+        self.zip_config = {
+            "include": ["*.py"].extend(custom_files.get("include", [])),
+            "exclude": ["build", "docs", "examples", "test", "tests", "venv"].extend(custom_files.get("include", [])),
         }
 
         self.func_path = func_path
@@ -106,7 +108,7 @@ class Backend:
                 raise
 
     def zip(self):
-        """Zips requirements.txt, python files and any additional files based on config.customFiles"""
+        """Zips requirements.txt, python files and any additional files based on config.custom_files"""
         self._zip_file("requirements.txt")
         if self.config.main_file:
             self._zip_file(self.config.main_file, "main.py")

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -30,10 +30,15 @@ class Backend:
 
         # specifies which files to be zipped
         custom_files = self.config.custom_files or {}
+        include = ["*.py"]
+        exclude = ["build", "docs", "examples", "test", "tests", "venv"]
 
+        include.extend(custom_files.get("include", []))
+        exclude.extend(custom_files.get("exclude", []))
+        
         self.zip_config = {
-            "include": ["*.py"].extend(custom_files.get("include", [])),
-            "exclude": ["build", "docs", "examples", "test", "tests", "venv"].extend(custom_files.get("include", [])),
+            "include": include,
+            "exclude": exclude
         }
 
         self.func_path = func_path

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -35,7 +35,7 @@ class Backend:
 
         include.extend(custom_files.get("include", []))
         exclude.extend(custom_files.get("exclude", []))
-        
+
         self.zip_config = {
             "include": include,
             "exclude": exclude

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -36,10 +36,7 @@ class Backend:
         include.extend(custom_files.get("include", []))
         exclude.extend(custom_files.get("exclude", []))
 
-        self.zip_config = {
-            "include": include,
-            "exclude": exclude
-        }
+        self.zip_config = {"include": include, "exclude": exclude}
 
         self.func_path = func_path
 

--- a/goblet/tests/test_backend.py
+++ b/goblet/tests/test_backend.py
@@ -1,0 +1,15 @@
+from goblet import Goblet
+from goblet.backends.backend import Backend
+
+
+class TestBackend:
+    def test_custom_files(self):
+        test_custom_files = {
+            "custom_files": {"include": ["*.yaml"], "exclude": [".secret"]}
+        }
+        backend = Backend(Goblet(), None, None, config=test_custom_files)
+
+        assert "*.yaml" in backend.zip_config["include"]
+        assert "*.py" in backend.zip_config["include"]
+        assert ".secret" in backend.zip_config["exclude"]
+        assert "build" in backend.zip_config["exclude"]


### PR DESCRIPTION
renamed custom_files. It now has format

```
"custom_files": {
      "include": ["*.yaml"],
      "exclude": ["*.secret"]
  }
```
