### PR TITLE
Add support for `content_types` and `tags` fields for openapi spec creation

### DIFF
--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -433,6 +433,12 @@ class OpenApiSpec:
         if entry.security:
             method_spec["security"] = entry.security
 
+        if entry.tags:
+            method_spec["tags"] = entry.tags
+
+        if entry.content_types:
+            method_spec["consumes"] = entry.content_types
+
         path_exists = self.spec["paths"].get(entry.uri_pattern)
         if path_exists:
             self.spec["paths"][entry.uri_pattern][entry.method.lower()] = dict(
@@ -490,6 +496,7 @@ class RouteEntry:
         self.responses = kwargs.get("responses")
         self.backend = kwargs.get("backend")
         self.security = kwargs.get("security")
+        self.tags = kwargs.get("tags")
         #: A list of names to extract from path:
         #: e.g, '/foo/{bar}/{baz}/qux -> ['bar', 'baz']
         self.view_args = self._parse_view_args()


### PR DESCRIPTION
Utilize the existing `content_types` field to allow users to specify `Content-Type:` header for request data, and add `tags` field to group endpoints under categories in Swagger docs