### PR TITLE
Bugfix252-parallel build artifacts

### DIFF
--- a/goblet/common_cloud_actions.py
+++ b/goblet/common_cloud_actions.py
@@ -171,25 +171,28 @@ class MissingArtifact(Exception):
 
 
 # calls latest build and checks for its artifact to avoid image:latest behavior with cloud run revisions
-def getCloudbuildArtifact(client):
+def getCloudbuildArtifact(client, artifactName):
     defaultProject = get_default_project()
     resp = client.execute(
         "list", parent_key="projectId", parent_schema=defaultProject, params={}
     )
-    latestBuildId = resp["builds"][0]["id"]
-    resp = client.execute(
-        "get",
-        parent_key="projectId",
-        parent_schema=defaultProject,
-        params={"id": latestBuildId},
-    )
-    try:
-        latestArtifact = (
-            resp["results"]["images"][0]["name"]
-            + "@"
-            + resp["results"]["images"][0]["digest"]
-        )
-    except KeyError:
+
+    # search for latest build with artifactName
+    latestArtifact = None
+    for build in resp["builds"]:
+        # pending builds will not have results field.
+        if (
+            build.get("results")
+            and artifactName == build["results"]["images"][0]["name"].split("/")[-1]
+        ):
+            latestArtifact = latestArtifact = (
+                build["results"]["images"][0]["name"]
+                + "@"
+                + build["results"]["images"][0]["digest"]
+            )
+            break
+
+    if not latestArtifact:
         raise MissingArtifact("Missing artifact. Cloud Build may have failed.")
     return latestArtifact
 

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -48,7 +48,9 @@ class Jobs(Handler):
             return
 
         config = GConfig(config=config)
-        artifact = getCloudbuildArtifact(self.versioned_clients.cloudbuild, self.name)
+        artifact = getCloudbuildArtifact(
+            self.versioned_clients.cloudbuild, self.name, config=config
+        )
 
         log.info("deploying cloudrun jobs......")
         for job_name, job in self.resources.items():

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -48,7 +48,7 @@ class Jobs(Handler):
             return
 
         config = GConfig(config=config)
-        artifact = getCloudbuildArtifact(self.versioned_clients.cloudbuild)
+        artifact = getCloudbuildArtifact(self.versioned_clients.cloudbuild, self.name)
 
         log.info("deploying cloudrun jobs......")
         for job_name, job in self.resources.items():

--- a/goblet/revision.py
+++ b/goblet/revision.py
@@ -99,7 +99,9 @@ class RevisionSpec:
         client = self.versioned_clients.run
         region = get_default_location()
         project = get_default_project_number()
-        self.latestArtifact = getCloudbuildArtifact(self.versioned_clients.cloudbuild)
+        self.latestArtifact = getCloudbuildArtifact(
+            self.versioned_clients.cloudbuild, self.name
+        )
         self.req_body = {
             "template": {
                 **self.cloudrun_revision,

--- a/goblet/revision.py
+++ b/goblet/revision.py
@@ -100,7 +100,7 @@ class RevisionSpec:
         region = get_default_location()
         project = get_default_project_number()
         self.latestArtifact = getCloudbuildArtifact(
-            self.versioned_clients.cloudbuild, self.name
+            self.versioned_clients.cloudbuild, self.name, config=self.config
         )
         self.req_body = {
             "template": {


### PR DESCRIPTION
* simplifies `getCloudbuildArtifact` and explicitly gets the artifact based on registry set during the build (closes #252 )