### PR TITLE
Cloudrun jobs metadata

### DIFF
--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -272,12 +272,16 @@ Jobs
 ^^^^
 
 You can create and trigger cloudrun jobs using the `@app.job(...)` decorator. If you would like to trigger multiple tasks in one job execution 
-you can specify multiple decorators with a different `task_id`. Any custom job configurations should be added to the `task_id=0`. Options can be found at 
-`Cloudrun Jobs  <https://cloud.google.com/static/run/docs/reference/rest/v1/namespaces.jobs#ExecutionTemplateSpec>`__
+you can specify multiple decorators with a different `task_id`. Any custom job configurations such as a schedule should be added to the `task_id=0`. Jobs can be further configured
+by setting various configs in `config.json.` 
 
-You can schedule executions by passing in a cron `schedule` to the first task.
+`jobs_metadata` can be found at `Cloudrun Jobs Metadata  <https://cloud.google.com/static/run/docs/reference/rest/v1/namespaces.jobs#ExecutionTemplateSpec>`__
 
-Each job task function takes in the task id. 
+`job_spec` can be found at `Cloudrun Jobs Spec  <https://cloud.google.com/run/docs/reference/rest/v1/TaskSpec>`__
+
+`job_container` can be found at `Cloudrun Jobs Container  <https://cloud.google.com/run/docs/reference/rest/v1/Container>`__
+
+You can schedule executions by passing in a cron `schedule` to the first task. Each job task function takes in the task id. 
 
 To test a job locally you can run `goblet job run APP_NAME-JOB_NAME TASK_ID`
 
@@ -299,3 +303,5 @@ Example usage:
     def job2(id):
         app.log.info(f"another job...{id}")
         return "200"
+
+See the example `config.json <https://github.com/goblet/goblet/blob/main/examples/example_cloudrun_job/config.json>`__

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -275,7 +275,7 @@ You can create and trigger cloudrun jobs using the `@app.job(...)` decorator. If
 you can specify multiple decorators with a different `task_id`. Any custom job configurations such as a schedule should be added to the `task_id=0`. Jobs can be further configured
 by setting various configs in `config.json.` 
 
-`jobs_metadata` can be found at `Cloudrun Jobs Metadata  <https://cloud.google.com/static/run/docs/reference/rest/v1/namespaces.jobs#ExecutionTemplateSpec>`__
+`jobs_annotations` can be found at `Cloudrun Jobs Metadata  <https://cloud.google.com/run/docs/reference/rest/v1/ObjectMeta>`__
 
 `job_spec` can be found at `Cloudrun Jobs Spec  <https://cloud.google.com/run/docs/reference/rest/v1/TaskSpec>`__
 

--- a/examples/example_cloudrun_job/config.json
+++ b/examples/example_cloudrun_job/config.json
@@ -19,7 +19,7 @@
         "timeoutSeconds":"600s",
         "maxRetries": 1
     },
-    "job_metadata":{
+    "job_annotations":{
         "run.googleapis.com/vpc-access-connector": "projects/PROJECT/locations/LOCATION/connectors/CONNECTION_NAME",
         "run.googleapis.com/cloudsql-instances": "projects/PROJECT/locations/LOCATION/connectors/SQL_CONNECTION",
         "run.googleapis.com/vpc-access-egress": "private-ranges-only"

--- a/examples/example_cloudrun_job/config.json
+++ b/examples/example_cloudrun_job/config.json
@@ -6,11 +6,23 @@
                 "name": "ENV",
                 "value": "VALUE"
             }
-        ]
+        ],
+        "resources": {
+            "limits": {
+                "cpu": "4000m",
+                "memory": "7000Mi"
+            }
+        }
     },
     "job_spec":{
         "serviceAccountName": "SA@PROJECT.iam.gserviceaccount.com",
-        "timeoutSeconds":"600s"
+        "timeoutSeconds":"600s",
+        "maxRetries": 1
+    },
+    "job_metadata":{
+        "run.googleapis.com/vpc-access-connector": "VPC_CONNECTOR",
+        "run.googleapis.com/cloudsql-instances": "SQL_CONNECTOR",
+        "run.googleapis.com/vpc-access-egress": "EGRESS"
     },
     "scheduler":{
         "serviceAccount": "SA_SCHEDULER@PROJECT.iam.gserviceaccount.com"

--- a/examples/example_cloudrun_job/config.json
+++ b/examples/example_cloudrun_job/config.json
@@ -20,9 +20,9 @@
         "maxRetries": 1
     },
     "job_metadata":{
-        "run.googleapis.com/vpc-access-connector": "VPC_CONNECTOR",
-        "run.googleapis.com/cloudsql-instances": "SQL_CONNECTOR",
-        "run.googleapis.com/vpc-access-egress": "EGRESS"
+        "run.googleapis.com/vpc-access-connector": "projects/PROJECT/locations/LOCATION/connectors/CONNECTION_NAME",
+        "run.googleapis.com/cloudsql-instances": "projects/PROJECT/locations/LOCATION/connectors/SQL_CONNECTION",
+        "run.googleapis.com/vpc-access-egress": "private-ranges-only"
     },
     "scheduler":{
         "serviceAccount": "SA_SCHEDULER@PROJECT.iam.gserviceaccount.com"

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 9, 0)
+VERSION = (0, 9, 1)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -56,6 +56,7 @@ class Jobs(Handler):
         for job_name, job in self.resources.items():
 
             container = {**(config.job_container or {})}
+            metadata = {**(config.job_metadata or {})}
             container["image"] = artifact
             container["command"] = [
                 "goblet",
@@ -70,6 +71,7 @@ class Jobs(Handler):
                 "metadata": {
                     "name": job_name,
                     "annotations": {"run.googleapis.com/launch-stage": "BETA"},
+                    **metadata
                 },
                 "spec": {
                     "template": {

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from importlib.metadata import metadata
 import logging
 
 from goblet.resources.handler import Handler
@@ -56,7 +58,7 @@ class Jobs(Handler):
         for job_name, job in self.resources.items():
 
             container = {**(config.job_container or {})}
-            metadata = {**(config.job_metadata or {})}
+            annotations = {**(config.job_annotations or {})}
             container["image"] = artifact
             container["command"] = [
                 "goblet",
@@ -71,10 +73,10 @@ class Jobs(Handler):
                 "metadata": {
                     "name": job_name,
                     "annotations": {"run.googleapis.com/launch-stage": "BETA"},
-                    **metadata,
                 },
                 "spec": {
                     "template": {
+                        "metadata": {"annotations": annotations},
                         "spec": {
                             "taskCount": len(job.keys()) - 1,
                             "template": {

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-from importlib.metadata import metadata
 import logging
 
 from goblet.resources.handler import Handler

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -71,7 +71,7 @@ class Jobs(Handler):
                 "metadata": {
                     "name": job_name,
                     "annotations": {"run.googleapis.com/launch-stage": "BETA"},
-                    **metadata
+                    **metadata,
                 },
                 "spec": {
                     "template": {


### PR DESCRIPTION
update cloudrun job example and support `job_metadata` pass through for vpc and networking configurations (closes #260 )

```
{
    "function_name":"FUNCTION_NAME",
    "job_container": {
        "env": [
            {
                "name": "ENV",
                "value": "VALUE"
            }
        ],
        "resources": {
            "limits": {
                "cpu": "4000m",
                "memory": "7000Mi"
            }
        }
    },
    "job_spec":{
        "serviceAccountName": "SA@PROJECT.iam.gserviceaccount.com",
        "timeoutSeconds":"600s",
        "maxRetries": 1
    },
   "job_annotations":{
        "run.googleapis.com/vpc-access-connector": "projects/PROJECT/locations/LOCATION/connectors/CONNECTION_NAME",
        "run.googleapis.com/cloudsql-instances": "projects/PROJECT/locations/LOCATION/connectors/SQL_CONNECTION",
        "run.googleapis.com/vpc-access-egress": "private-ranges-only"
    },
    "scheduler":{
        "serviceAccount": "SA_SCHEDULER@PROJECT.iam.gserviceaccount.com"
    }
}
```