### PR TITLE
Fix key error

### DIFF
--- a/goblet/common_cloud_actions.py
+++ b/goblet/common_cloud_actions.py
@@ -187,7 +187,11 @@ def getCloudbuildArtifact(client, artifactName, config):
 
     for build in resp["builds"]:
         # pending builds will not have results field.
-        if build.get("results") and registry == build["results"]["images"][0]["name"]:
+        if (
+            build.get("results")
+            and build["results"].get("images")
+            and registry == build["results"]["images"][0]["name"]
+        ):
             latestArtifact = latestArtifact = (
                 build["results"]["images"][0]["name"]
                 + "@"


### PR DESCRIPTION
I am not sure what causes this, but every once in a while I get this error:

>   File "/Users/adeel/Library/Caches/pypoetry/virtualenvs/cloud-run-test-2YUWirjE-py3.10/lib/python3.10/site-packages/goblet/common_cloud_actions.py", line 190, in getCloudbuildArtifact
    if build.get("results") and registry == build["results"]["images"][0]["name"]:
KeyError: 'images'

I guess not every build result has an image? Anyways, more safely accessing keys like this results in a successful deployment