### PR TITLE
Add gcloud logger

### DIFF
--- a/goblet/app.py
+++ b/goblet/app.py
@@ -56,15 +56,17 @@ class Goblet(Register_Handlers):
         # Setup Local
         module_name = GConfig().main_file or "main"
         module_name = module_name.replace(".py", "")
-        if local and os.environ.get("X-GOBLET-LOCAL"):
-            logging.basicConfig()
-            self.log = logging.getLogger("werkzeug")
+        if local and sys.modules.get(module_name):
 
             def local_func(request):
                 return self(request)
 
             setattr(sys.modules[module_name], local, local_func)
 
+        # configure logging for local or gcp
+        if os.environ.get("X-GOBLET-LOCAL") or os.environ.get("GOBLET_HTTP_TEST"):
+            logging.basicConfig()
+            self.log = logging.getLogger("werkzeug")
         elif not os.environ.get("X-GOBLET-DEPLOY"):
             self.log.handlers.clear()
             handler = StructuredLogHandler()

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -1,10 +1,13 @@
 import json
 import logging
 import sys
+import os
 
 from goblet.client import DEFAULT_CLIENT_VERSIONS
 from goblet.config import GConfig
 from goblet.decorators import Register_Handlers
+from google.cloud.logging.handlers import StructuredLogHandler
+from google.cloud.logging_v2.handlers import setup_logging
 
 logging.basicConfig()
 
@@ -27,6 +30,7 @@ class Goblet(Register_Handlers):
         client_versions=None,
         routes_type="apigateway",
         config={},
+        log_level=logging.INFO,
     ):
         self.client_versions = DEFAULT_CLIENT_VERSIONS
         self.client_versions.update(client_versions or {})
@@ -52,13 +56,20 @@ class Goblet(Register_Handlers):
         # Setup Local
         module_name = GConfig().main_file or "main"
         module_name = module_name.replace(".py", "")
-        if local and sys.modules.get(module_name):
+        if local and os.environ.get("X-GOBLET-LOCAL"):
+            logging.basicConfig()
             self.log = logging.getLogger("werkzeug")
 
             def local_func(request):
                 return self(request)
 
             setattr(sys.modules[module_name], local, local_func)
+
+        elif not os.environ.get("X-GOBLET-DEPLOY"):
+            self.log.handlers.clear()
+            handler = StructuredLogHandler()
+            setup_logging(handler, log_level=log_level)
+            self.log = logging.getLogger(__name__)
 
     def deploy(
         self,

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -61,6 +61,7 @@ def deploy(
 
     Note: Make sure api-gateway, cloudfunctions, and storage are enabled in your project
     """
+    os.environ["X-GOBLET-DEPLOY"] = "true"
     try:
         _project = project or get_default_project()
         if not _project:
@@ -117,6 +118,7 @@ def destroy(project, location, stage, all, skip_infra):
 
     The --all flag removes cloudfunction artifacts in cloud storage as well
     """
+    os.environ["X-GOBLET-DEPLOY"] = "true"
     try:
         _project = project or get_default_project()
         if not _project:
@@ -160,6 +162,7 @@ def sync(project, location, stage, dryrun):
 
     Use --dryrun flag to see what resources are flagged as being deleted.
     """
+    os.environ["X-GOBLET-DEPLOY"] = "true"
     try:
         _project = project or get_default_project()
         if not _project:
@@ -190,6 +193,7 @@ def openapi(cloudfunction, stage, version):
 
     The cloudfunction argument sets the correct x-google-backend address in the openapi spec.
     """
+    os.environ["X-GOBLET-DEPLOY"] = "true"
     if stage:
         os.environ["STAGE"] = stage
     try:
@@ -227,6 +231,7 @@ def local(local_arg, stage, port):
 
     Goblet("test_function",local="local_function")
     """
+    os.environ["X-GOBLET-LOCAL"] = "true"
     try:
         if stage:
             os.environ["STAGE"] = stage
@@ -251,6 +256,7 @@ def local(local_arg, stage, port):
 @main.command()
 def package(stage):
     """generates the goblet zipped package in .goblet folder"""
+    os.environ["X-GOBLET-DEPLOY"] = "true"
     try:
         if stage:
             os.environ["STAGE"] = stage
@@ -297,6 +303,7 @@ def list_stages():
 )
 def create(stage):
     """create a new stage in config.json"""
+    os.environ["X-GOBLET-DEPLOY"] = "true"
     config = GConfig()
     if config.stages and stage in config.stages:
         return click.echo(f"stage {stage} already exists")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ marshmallow==3.15.0
 pydantic==1.10.2
 ruamel.yaml==0.17.21
 markupsafe==2.0.1
+google-cloud-logging==3.1.2

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ REQUIRED = [
     "marshmallow",
     "pydantic",
     "ruamel.yaml",
+    "google-cloud-logging"
 ]
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
logger should return json structured logs when deployed in gcp. can pass in extra json data using `extra` field in logs
see https://googleapis.dev/python/logging/latest/std-lib-integration.html#logging-json-payloads (closes #159 #264  )

@AdeelK93 let me know if this would work for you  