### PR TITLE
Backend http endpoint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Run pytest
         run: |
           export PYTHONPATH=$(pwd)
+          export X-GOBLET-LOCAL=true
           coverage run -m pytest goblet/tests;
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 9, 2)
+VERSION = (0, 9, 3)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/backends/__init__.py
+++ b/goblet/backends/__init__.py
@@ -1,0 +1,3 @@
+from goblet.backends.cloudrun import CloudRun  # noqa: F401
+from goblet.backends.cloudfunctionv1 import CloudFunctionV1  # noqa: F401
+from goblet.backends.cloudfunctionv2 import CloudFunctionV2  # noqa: F401

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -114,6 +114,10 @@ class Backend:
             if e.resp.status != 404:
                 raise
 
+    @property
+    def http_endpoint(self):
+        raise NotImplementedError("http_endpoint")
+
     def zip(self):
         """Zips python files and any additional files based on config.custom_files"""
         if self.config.requirements_file:

--- a/goblet/backends/cloudfunctionv1.py
+++ b/goblet/backends/cloudfunctionv1.py
@@ -8,6 +8,7 @@ from goblet.common_cloud_actions import (
     create_cloudfunctionv1,
     destroy_cloudfunction_artifacts,
     destroy_cloudfunction,
+    get_cloudfunction_url,
 )
 
 
@@ -88,3 +89,7 @@ class CloudFunctionV1(Backend):
         self.config.update_g_config(
             values=config_updates, write_config=write_config, stage=stage
         )
+
+    @property
+    def http_endpoint(self):
+        return get_cloudfunction_url(self.client, self.name)

--- a/goblet/backends/cloudfunctionv2.py
+++ b/goblet/backends/cloudfunctionv2.py
@@ -100,3 +100,7 @@ class CloudFunctionV2(Backend):
         self.config.update_g_config(
             values=config_updates, write_config=write_config, stage=stage
         )
+
+    @property
+    def http_endpoint(self):
+        return self.func_path

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -10,6 +10,7 @@ from goblet.common_cloud_actions import (
     create_cloudbuild,
     destroy_cloudrun,
     destroy_cloudfunction_artifacts,
+    get_cloudrun_url,
 )
 from goblet.revision import RevisionSpec
 from goblet.utils import get_dir
@@ -176,3 +177,7 @@ class CloudRun(Backend):
             write_config=write_config,
             stage=stage,
         )
+
+    @property()
+    def http_endpoint(self):
+        return get_cloudrun_url(self.client, self.name)

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -178,6 +178,6 @@ class CloudRun(Backend):
             stage=stage,
         )
 
-    @property()
+    @property
     def http_endpoint(self):
         return get_cloudrun_url(self.client, self.name)

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -211,7 +211,7 @@ class Register_Handlers(DecoratorAPI):
     def __init__(
         self,
         function_name,
-        backend="cloudfunction",
+        backend,
         cors=None,
         client_versions=None,
         routes_type="apigateway",

--- a/goblet/infrastructures/infrastructure.py
+++ b/goblet/infrastructures/infrastructure.py
@@ -10,7 +10,7 @@ class Infrastructure:
     def __init__(
         self,
         name,
-        backend="cloudfunction",
+        backend=None,
         versioned_clients: VersionedClients = None,
         resource=None,
         config={},

--- a/goblet/resources/eventarc.py
+++ b/goblet/resources/eventarc.py
@@ -25,9 +25,7 @@ class EventArc(Handler):
     valid_backends = ["cloudrun"]
     can_sync = True
 
-    def __init__(
-        self, name, versioned_clients=None, resources=None, backend="cloudfunction"
-    ):
+    def __init__(self, name, backend, versioned_clients=None, resources=None):
         super(EventArc, self).__init__(
             name,
             versioned_clients=versioned_clients,

--- a/goblet/resources/handler.py
+++ b/goblet/resources/handler.py
@@ -1,6 +1,7 @@
 import logging
 
 from goblet.client import VersionedClients, get_default_location, get_default_project
+from goblet.backends import CloudFunctionV1
 
 log = logging.getLogger("goblet.deployer")
 log.setLevel(logging.INFO)
@@ -12,15 +13,15 @@ class Handler:
     valid_backends = []
     resources = None
     resource_type = ""
-    backend = "cloudfunction"
+    backend = ""
     can_sync = False
 
     def __init__(
         self,
         name,
+        backend,
         versioned_clients: VersionedClients = None,
         resources=None,
-        backend="cloudfunction",
     ):
         self.name = name
         self.backend = backend
@@ -29,9 +30,9 @@ class Handler:
         self.cloudfunction = f"projects/{get_default_project()}/locations/{get_default_location()}/functions/{name}"
 
     def deploy(self, source=None, entrypoint=None, config={}):
-        if self.resources and self.backend not in self.valid_backends:
+        if self.resources and self.backend.resource_type not in self.valid_backends:
             log.info(
-                f"skipping... {self.backend} not supported for {self.resource_type}"
+                f"skipping... {self.backend.resource_type} not supported for {self.resource_type}"
             )
             return
         self._deploy(source, entrypoint, config=config)

--- a/goblet/resources/http.py
+++ b/goblet/resources/http.py
@@ -8,12 +8,7 @@ class HTTP(Handler):
     valid_backends = ["cloudfunction", "cloudfunctionv2", "cloudrun"]
 
     def __init__(
-        self,
-        name,
-        versioned_clients=None,
-        cors=None,
-        resources=None,
-        backend="cloudfunction",
+        self, name, backend, versioned_clients=None, cors=None, resources=None
     ):
         super(HTTP, self).__init__(
             name=name,

--- a/goblet/resources/pubsub.py
+++ b/goblet/resources/pubsub.py
@@ -2,8 +2,6 @@ import base64
 from goblet.common_cloud_actions import (
     create_pubsub_subscription,
     destroy_pubsub_subscription,
-    get_cloudrun_url,
-    get_cloudfunction_url,
     get_function_runtime,
     create_cloudfunctionv2,
     create_cloudfunctionv1,
@@ -114,12 +112,8 @@ class PubSub(Handler):
     def _deploy_subscription(self, topic_name, topic, config={}):
         sub_name = f"{self.name}-{topic_name}"
         log.info(f"deploying pubsub subscription {sub_name}......")
-        if self.backend == "cloudrun":
-            push_url = get_cloudrun_url(self.versioned_clients.run, self.name)
-        else:
-            push_url = get_cloudfunction_url(
-                self.versioned_clients.cloudfunctions, self.name
-            )
+
+        push_url = self.backend.http_endpoint
 
         gconfig = GConfig(config=config)
         if gconfig.pubsub and gconfig.pubsub.get("serviceAccountEmail"):

--- a/goblet/resources/pubsub.py
+++ b/goblet/resources/pubsub.py
@@ -41,7 +41,7 @@ class PubSub(Handler):
         if (
             kwargs.get("use_subscription")
             or project != get_default_project()
-            or self.backend == "cloudrun"
+            or self.backend.resource_type == "cloudrun"
         ):
             deploy_type = "subscription"
 
@@ -119,13 +119,13 @@ class PubSub(Handler):
         if gconfig.pubsub and gconfig.pubsub.get("serviceAccountEmail"):
             service_account = gconfig.pubsub.get("serviceAccountEmail")
         elif (
-            self.backend == "cloudrun"
+            self.backend.resource_type == "cloudrun"
             and gconfig.cloudrun
             and gconfig.cloudrun.get("service-account")
         ):
             service_account = gconfig.cloudrun.get("service-account")
         elif (
-            self.backend.startswith("cloudfunction")
+            self.backend.resource_type.startswith("cloudfunction")
             and gconfig.cloudfunction
             and gconfig.pubsub.get("serviceAccountEmail")
         ):

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -37,10 +37,10 @@ class ApiGateway(Handler):
     def __init__(
         self,
         name,
+        backend,
         versioned_clients=None,
         cors=None,
         resources=None,
-        backend="cloudfunction",
         routes_type="apigateway",
     ):
         super(ApiGateway, self).__init__(
@@ -114,7 +114,7 @@ class ApiGateway(Handler):
         gconfig = GConfig(config)
         if (
             self.routes_type != "apigateway"
-            and self.backend.startswith("cloudfunction")
+            and self.backend.resource_type.startswith("cloudfunction")
             and self.versioned_clients.cloudfunctions == "v1"
         ):
             raise ValueError(
@@ -291,15 +291,15 @@ class ApiGateway(Handler):
     def get_timeout(self, config):
         # get api gateway timeout
         deadline = (config.api_gateway or {}).get("deadline")
-        if self.backend == "cloudfunction" and not deadline:
+        if self.backend.resource_type == "cloudfunction" and not deadline:
             deadline = (config.cloudfunction or {}).get("timeout")
-        if self.backend == "cloudfunctionv2" and not deadline:
+        if self.backend.resource_type == "cloudfunctionv2" and not deadline:
             deadline = (
                 (config.cloudfunction or {})
                 .get("serviceConfig", {})
                 .get("timeoutSeconds")
             )
-        if self.backend == "cloudrun" and not deadline:
+        if self.backend.resource_type == "cloudrun" and not deadline:
             deadline = (config.cloudrun_revision or {}).get("timeout")
         # default deadline to 15 seconds, which is gcp api gateway default
         return deadline or 15

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -16,7 +16,6 @@ from goblet.client import get_default_project
 from goblet.resources.plugins.pydantic import PydanticPlugin
 from goblet.utils import get_g_dir
 from goblet.config import GConfig
-from goblet.common_cloud_actions import get_cloudrun_url, get_cloudfunction_url
 
 import ruamel.yaml
 
@@ -124,12 +123,7 @@ class ApiGateway(Handler):
         if len(self.resources) == 0 or self.routes_type != "apigateway":
             return
         log.info("deploying api......")
-        if self.backend.startswith("cloudfunction"):
-            base_url = get_cloudfunction_url(
-                self.versioned_clients.cloudfunctions, self.name
-            )
-        if self.backend == "cloudrun":
-            base_url = get_cloudrun_url(self.versioned_clients.run, self.name)
+        base_url = self.backend.http_endpoint
         self.generate_openapi_spec(base_url)
         try:
             resp = self.versioned_clients.apigateway_api.execute(

--- a/goblet/resources/scheduler.py
+++ b/goblet/resources/scheduler.py
@@ -85,7 +85,7 @@ class Scheduler(Handler):
         if not self.resources:
             return
 
-        if self.backend.startswith("cloudfunction"):
+        if self.backend.resource_type.startswith("cloudfunction"):
             resp = self.versioned_clients.cloudfunctions.execute(
                 "get", parent_key="name", parent_schema=self.cloudfunction
             )
@@ -98,7 +98,7 @@ class Scheduler(Handler):
                 target = resp["serviceConfig"]["uri"]
                 service_account = resp["serviceConfig"]["serviceAccountEmail"]
 
-        if self.backend == "cloudrun":
+        if self.backend.resource_type == "cloudrun":
             # dont get target in scheduler is needed only for jobs
             cloudrun_target = None
             config = GConfig(config=config)
@@ -116,7 +116,7 @@ class Scheduler(Handler):
         for job_name, job in self.resources.items():
             if job["uri"]:
                 target = job["uri"]
-            elif self.backend.startswith("cloudfunction"):
+            elif self.backend.resource_type.startswith("cloudfunction"):
                 target = target
             else:
                 # only run once

--- a/goblet/resources/storage.py
+++ b/goblet/resources/storage.py
@@ -27,9 +27,7 @@ class Storage(Handler):
     resource_type = "storage"
     valid_backends = ["cloudfunction", "cloudfunctionv2"]
 
-    def __init__(
-        self, name, versioned_clients=None, resources=None, backend="cloudfunction"
-    ):
+    def __init__(self, name, backend, versioned_clients=None, resources=None):
         super(Storage, self).__init__(
             name,
             versioned_clients=versioned_clients,

--- a/goblet/tests/test_deployer.py
+++ b/goblet/tests/test_deployer.py
@@ -17,7 +17,7 @@ class TestDeployer:
         app = Goblet(function_name="goblet_example")
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"] = HTTP(dummy_function)
+        app.handlers["http"] = HTTP("name", app)
 
         app.deploy(skip_resources=True, skip_infra=True, force=True)
 
@@ -58,7 +58,7 @@ class TestDeployer:
         app = Goblet(function_name="goblet", backend="cloudrun")
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"] = HTTP(dummy_function)
+        app.handlers["http"] = HTTP("name", app)
 
         app.deploy(
             skip_resources=True,
@@ -85,7 +85,7 @@ class TestDeployer:
         app = Goblet(function_name="goblet", backend="cloudrun")
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"] = HTTP(dummy_function)
+        app.handlers["http"] = HTTP("name", app)
         with pytest.raises(GobletError):
             app.deploy(
                 skip_resources=True,
@@ -155,7 +155,7 @@ class TestDeployer:
         app = Goblet(function_name="goblet_bindings")
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"] = HTTP(dummy_function)
+        app.handlers["http"] = HTTP("name", app)
         bindings = [{"role": "roles/cloudfunctions.invoker", "members": ["allUsers"]}]
         app.deploy(
             skip_resources=True,
@@ -198,7 +198,7 @@ class TestDeployer:
         app = Goblet(function_name="goblet", backend="cloudrun")
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"] = HTTP(dummy_function)
+        app.handlers["http"] = HTTP("name", app)
 
         app.deploy(
             skip_resources=True,

--- a/goblet/tests/test_eventarc.py
+++ b/goblet/tests/test_eventarc.py
@@ -5,6 +5,7 @@ from goblet.test_utils import (
     dummy_function,
     mock_dummy_function,
 )
+from goblet.backends.cloudrun import CloudRun
 
 from unittest.mock import Mock
 
@@ -87,7 +88,7 @@ class TestEventArc:
 
         eventarc = EventArc(
             "test-eventarc",
-            backend="cloudrun",
+            backend=CloudRun(Goblet(function_name="test-eventarc", backend="cloudrun")),
             resources=[
                 {
                     "trigger_name": "test-eventarc-bucket-get",
@@ -125,7 +126,7 @@ class TestEventArc:
 
         eventarc = EventArc(
             "test-eventarc",
-            backend="cloudrun",
+            backend=CloudRun(Goblet(function_name="test-eventarc", backend="cloudrun")),
             resources=[
                 {
                     "trigger_name": "test-eventarc-bucket-get",
@@ -163,7 +164,7 @@ class TestEventArc:
 
         eventarc = EventArc(
             "test-eventarc",
-            backend="cloudrun",
+            backend=CloudRun(Goblet(function_name="test-eventarc", backend="cloudrun")),
             resources=[
                 {
                     "trigger_name": "test-eventarc-bucket-get",
@@ -202,7 +203,7 @@ class TestEventArc:
 
         eventarc = EventArc(
             "test-eventarc",
-            backend="cloudrun",
+            backend=CloudRun(Goblet(function_name="test-eventarc", backend="cloudrun")),
             resources=[
                 {
                     "trigger_name": "test-eventarc-bucket-get",

--- a/goblet/tests/test_jobs.py
+++ b/goblet/tests/test_jobs.py
@@ -10,6 +10,8 @@ from goblet.test_utils import (
     mock_dummy_function,
 )
 
+from goblet.backends import CloudFunctionV1
+
 
 class TestJobs:
     def test_add_job(self):
@@ -80,7 +82,9 @@ class TestJobs:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "test-job"
-        jobs = Jobs(goblet_name)
+        jobs = Jobs(
+            goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
+        )
         jobs.register_job("test", None, {"task_id": 0})
         jobs._deploy()
 
@@ -121,7 +125,7 @@ class TestJobs:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "test-job"
-        jobs = Jobs(goblet_name)
+        jobs = Jobs(goblet_name, Goblet(function_name="test-job"))
         jobs.register_job("test2", None, {"task_id": 0})
         jobs.sync()
 
@@ -136,7 +140,7 @@ class TestJobs:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "goblet-test"
-        jobs = Jobs(goblet_name)
+        jobs = Jobs(goblet_name, Goblet(function_name=goblet_name))
         jobs.register_job("test", None, {"task_id": 0})
         jobs.destroy()
 

--- a/goblet/tests/test_pubsub.py
+++ b/goblet/tests/test_pubsub.py
@@ -11,6 +11,7 @@ from goblet.test_utils import (
     get_response,
     mock_dummy_function,
 )
+from goblet.backends import CloudRun, CloudFunctionV1
 
 
 class TestPubSub:
@@ -288,6 +289,7 @@ class TestPubSub:
 
         pubsub = PubSub(
             "goblet_topic",
+            backend=CloudFunctionV1(Goblet()),
             resources={
                 "test-topic": {"trigger": {"test-topic": {}}, "subscription": {}}
             },
@@ -308,7 +310,7 @@ class TestPubSub:
         monkeypatch.setenv("GOBLET_TEST_NAME", "pubsub-deploy-cloudrun")
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
-        pubsub = PubSub("goblet", backend="cloudrun")
+        pubsub = PubSub("goblet", backend=CloudRun(Goblet(backend="cloudrun")))
         pubsub.register_topic("test", None, kwargs={"topic": "test", "kwargs": {}})
 
         cloudrun_url = "https://goblet-12345.a.run.app"
@@ -339,7 +341,7 @@ class TestPubSub:
         pubsub = PubSub(
             "goblet",
             resources={"test": {"trigger": {}, "subscription": {"test": {}}}},
-            backend="cloudrun",
+            backend=CloudRun(Goblet(backend="cloudrun")),
         )
         pubsub.destroy()
 
@@ -354,7 +356,10 @@ class TestPubSub:
         monkeypatch.setenv("GOBLET_TEST_NAME", "pubsub-update-subscription")
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
-        pubsub = PubSub("test-cross-project")
+        pubsub = PubSub(
+            "test-cross-project",
+            backend=CloudFunctionV1(Goblet()),
+        )
         pubsub.register_topic(
             "test",
             None,
@@ -379,7 +384,7 @@ class TestPubSub:
         monkeypatch.setenv("GOBLET_TEST_NAME", "pubsub-sync-cloudrun")
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
-        pubsub = PubSub("goblet", backend="cloudrun")
+        pubsub = PubSub("goblet", backend=CloudRun(Goblet(backend="cloudrun")))
         pubsub.sync(dryrun=True)
         pubsub.sync()
 

--- a/goblet/tests/test_scheduler.py
+++ b/goblet/tests/test_scheduler.py
@@ -7,6 +7,7 @@ from goblet.test_utils import (
     mock_dummy_function,
     dummy_function,
 )
+from goblet.backends import CloudRun, CloudFunctionV1
 
 
 class TestScheduler:
@@ -122,7 +123,7 @@ class TestScheduler:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "goblet_example"
-        scheduler = Scheduler(goblet_name)
+        scheduler = Scheduler(goblet_name, backend=CloudFunctionV1(Goblet()))
         scheduler.register_job(
             "test-job",
             None,
@@ -147,7 +148,7 @@ class TestScheduler:
         monkeypatch.setenv("GOBLET_TEST_NAME", "schedule-deploy-cloudrun")
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
-        scheduler = Scheduler("goblet", backend="cloudrun")
+        scheduler = Scheduler("goblet", backend=CloudRun(Goblet(backend="cloudrun")))
         cloudrun_url = "https://goblet-12345.a.run.app"
         service_account = "SERVICE_ACCOUNT@developer.gserviceaccount.com"
         scheduler.register_job(
@@ -176,7 +177,9 @@ class TestScheduler:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "goblet-test-schedule"
-        scheduler = Scheduler(goblet_name)
+        scheduler = Scheduler(
+            goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
+        )
         scheduler.register_job(
             "test-job",
             None,
@@ -234,7 +237,9 @@ class TestScheduler:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "goblet_example"
-        scheduler = Scheduler(goblet_name)
+        scheduler = Scheduler(
+            goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
+        )
         scheduler.register_job(
             "test-job",
             None,
@@ -254,7 +259,7 @@ class TestScheduler:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         goblet_name = "goblet"
-        scheduler = Scheduler(goblet_name)
+        scheduler = Scheduler(goblet_name, backend=CloudFunctionV1(Goblet()))
         scheduler.register_job(
             "scheduled_job",
             None,

--- a/goblet/tests/test_storage.py
+++ b/goblet/tests/test_storage.py
@@ -1,7 +1,7 @@
 from goblet import Goblet
 from goblet.resources.storage import Storage
 from goblet.test_utils import get_responses, dummy_function, mock_dummy_function
-
+from goblet.backends import CloudFunctionV1
 from unittest.mock import Mock
 import pytest
 
@@ -80,6 +80,7 @@ class TestStorage:
         storage = Storage(
             "goblet_storage",
             resources=[{"bucket": "test", "event_type": "finalize", "name": "test"}],
+            backend=CloudFunctionV1(Goblet(backend="cloudrun")),
         )
         storage.destroy()
 


### PR DESCRIPTION
Updated logic to pass through the backend class to the resource and infra handlers instead of just the backend string name. This allows us to add some backend properties that can be used by the various resources. 

such as 

`self.backend.http_endpoint`