### PR TITLE
[Routes] Pass through custom deadline field

### DIFF
--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -90,6 +90,15 @@ The argument names for the view function must match the name of the captured arg
     def users(first, second):
         return {'first': first, 'second': second}
 
+By default there is a timeout on api gateway of 15 seconds. This can be overriden by setting `"api_gateway": {"deadline": 45}` in `config.json`. You 
+can configure a per route deadline by passing in the deadline parameter in your route. 
+
+.. code:: python 
+
+    @app.route('/deadline', deadline=10)
+    def deadline():
+        return 'custom_deadline'
+
 By default routes are deployed to an api gateway. For cloudrun you have the option to use `route_type=cloudrun` to simply use the cloudrun 
 instance itself. The routes work the same as with an apigateway, but you would access the api via the cloudrun url instead of the api gateway url.
 

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -388,7 +388,7 @@ class OpenApiSpec:
             "address": entry.backend or self.cloudfunction,
             "protocol": "h2",
             "path_translation": "APPEND_PATH_TO_ADDRESS",
-            "deadline": self.deadline,
+            "deadline": entry.deadline or self.deadline,
         }
         method_spec["operationId"] = f"{entry.method.lower()}_{entry.function_name}"
 
@@ -501,6 +501,7 @@ class RouteEntry:
         self.backend = kwargs.get("backend")
         self.security = kwargs.get("security")
         self.tags = kwargs.get("tags")
+        self.deadline = kwargs.get("deadline")
         #: A list of names to extract from path:
         #: e.g, '/foo/{bar}/{baz}/qux -> ['bar', 'baz']
         self.view_args = self._parse_view_args()

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -49,14 +49,21 @@ class TestOpenApiSpec:
         assert spec.spec["paths"] == expected_json
 
     def test_custom_deadlines(self):
-        route = RouteEntry(dummy, "route", "/home", "GET",)
+        route = RouteEntry(
+            dummy,
+            "route",
+            "/home",
+            "GET",
+        )
         route2 = RouteEntry(dummy, "deadline", "/deadline", "GET", deadline=30)
         spec = OpenApiSpec("test", "xyz.cloudfunction", deadline=10)
         spec.add_route(route)
         spec.add_route(route2)
 
         assert spec.spec["paths"]["/home"]["get"]["x-google-backend"]["deadline"] == 10
-        assert spec.spec["paths"]["/deadline"]["get"]["x-google-backend"]["deadline"] == 30
+        assert (
+            spec.spec["paths"]["/deadline"]["get"]["x-google-backend"]["deadline"] == 30
+        )
 
     def test_add_route_post(self):
         route = RouteEntry(dummy, "route", "/home", "GET")

--- a/goblet/tests/test_openapispec.py
+++ b/goblet/tests/test_openapispec.py
@@ -48,6 +48,16 @@ class TestOpenApiSpec:
         }
         assert spec.spec["paths"] == expected_json
 
+    def test_custom_deadlines(self):
+        route = RouteEntry(dummy, "route", "/home", "GET",)
+        route2 = RouteEntry(dummy, "deadline", "/deadline", "GET", deadline=30)
+        spec = OpenApiSpec("test", "xyz.cloudfunction", deadline=10)
+        spec.add_route(route)
+        spec.add_route(route2)
+
+        assert spec.spec["paths"]["/home"]["get"]["x-google-backend"]["deadline"] == 10
+        assert spec.spec["paths"]["/deadline"]["get"]["x-google-backend"]["deadline"] == 30
+
     def test_add_route_post(self):
         route = RouteEntry(dummy, "route", "/home", "GET")
         route_post = RouteEntry(dummy, "route", "/home", "POST")


### PR DESCRIPTION
closes #291 

```
    @app.route('/deadline', deadline=10)
    def deadline():
        return 'custom_deadline'
```