### PR TITLE
[Local] Add set-env flag to goblet local command

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -273,6 +273,13 @@ The goblet app will run on port 8080 by default. You can specify a custom port w
 
     goblet local -p 6000
 
+You can set environment variables defined in your `config.json` locally by passing in the `--set-env` flag. Note that 
+this will pass through environment variables set in a stage as well if you specify the `--stage` flag. 
+
+.. code:: sh 
+
+    goblet local --set-env --stage dev
+
 Debugging with VScode
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -144,3 +144,6 @@ class Backend:
         for path in globbed_files:
             if not set(path.parts).intersection(exclusion_set):
                 self.zipf.write(str(path))
+
+    def get_environment_vars(self):
+        raise NotImplementedError("get_environment_vars")

--- a/goblet/backends/cloudfunctionv1.py
+++ b/goblet/backends/cloudfunctionv1.py
@@ -92,3 +92,8 @@ class CloudFunctionV1(Backend):
     @property
     def http_endpoint(self):
         return self.func_path
+
+    def get_environment_vars(self):
+        return self.config.config.get("cloudfunction", {}).get(
+            "environmentVariables", {}
+        )

--- a/goblet/backends/cloudfunctionv2.py
+++ b/goblet/backends/cloudfunctionv2.py
@@ -105,3 +105,10 @@ class CloudFunctionV2(Backend):
     @property
     def http_endpoint(self):
         return get_cloudfunction_url(self.client, self.name)
+
+    def get_environment_vars(self):
+        return (
+            self.config.config.get("cloudfunction", {})
+            .get("serviceConfig", {})
+            .get("environmentVariables", {})
+        )

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -181,3 +181,10 @@ class CloudRun(Backend):
     @property
     def http_endpoint(self):
         return get_cloudrun_url(self.client, self.name)
+
+    def get_environment_vars(self):
+        env_dict = {}
+        env = self.config.config.get("cloudrun_container", {}).get("env", [])
+        for env_item in env:
+            env_dict[env_item["name"]] = env_item["value"]
+        return env_dict

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -223,7 +223,8 @@ def openapi(cloudfunction, stage, version):
 @click.argument("local_arg", default="local")
 @click.option("-s", "--stage", "stage", envvar="STAGE")
 @click.option("-p", "--port", "port", envvar="PORT", default=8080)
-def local(local_arg, stage, port):
+@click.option("--set-env", "set_env", is_flag=True)
+def local(local_arg, stage, port, set_env):
     """
     Requires the local argument to be set in the Goblet class. The default is local.
 
@@ -237,6 +238,11 @@ def local(local_arg, stage, port):
             os.environ["STAGE"] = stage
         config = GConfig()
         source = config.main_file or "main.py"
+        if set_env:
+            app = get_goblet_app(source)
+            env_dict = app.backend.get_environment_vars()
+            for k, v in env_dict.items():
+                os.environ[k] = v
         subprocess.check_output(
             [
                 "functions-framework",

--- a/goblet/tests/test_backend.py
+++ b/goblet/tests/test_backend.py
@@ -1,5 +1,6 @@
 from goblet import Goblet
 from goblet.backends.backend import Backend
+from goblet.backends import CloudFunctionV1, CloudFunctionV2, CloudRun
 
 
 class TestBackend:
@@ -15,3 +16,28 @@ class TestBackend:
         assert "*.py" in backend.zip_config["include"]
         assert ".secret" in backend.zip_config["exclude"]
         assert "build" in backend.zip_config["exclude"]
+
+    def test_get_env_cloudfunction_v1(self):
+
+        test_env = {"cloudfunction": {"environmentVariables": {"TEST": "VALUE"}}}
+        backend = CloudFunctionV1(Goblet(), config=test_env)
+
+        assert backend.get_environment_vars() == {"TEST": "VALUE"}
+
+    def test_get_env_cloudfunction_v2(self):
+
+        test_env = {
+            "cloudfunction": {
+                "serviceConfig": {"environmentVariables": {"TEST": "VALUE"}}
+            }
+        }
+        backend = CloudFunctionV2(Goblet(), config=test_env)
+
+        assert backend.get_environment_vars() == {"TEST": "VALUE"}
+
+    def test_get_env_cloudrun(self):
+
+        test_env = {"cloudrun_container": {"env": [{"name": "TEST", "value": "VALUE"}]}}
+        backend = CloudRun(Goblet(), config=test_env)
+
+        assert backend.get_environment_vars() == {"TEST": "VALUE"}


### PR DESCRIPTION
`goblet local --set-env --stage dev` which would set the environment variables in that stage (closes #282 ).

