### PR TITLE
[cloudrun] enable cloudbuild network for cloudbuild step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ FROM python:3.10-slim
 ENV APP_HOME /app
 WORKDIR $APP_HOME
 
-# Install dependencies.
-RUN pip install keyrings.google-artifactregistry-auth==1.1.1
+# install keyring backend to handle artifact registry authentication
+# RUN pip install keyrings.google-artifactregistry-auth==1.1.1
 
+# Install dependencies.
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV APP_HOME /app
 WORKDIR $APP_HOME
 
 # Install dependencies.
+RUN pip install keyrings.google-artifactregistry-auth==1.1.1
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 

--- a/docs/source/backends.rst
+++ b/docs/source/backends.rst
@@ -111,3 +111,9 @@ In order to set a custom artifact registry, use the "artifact_registry" configur
             "serviceAccount": "service-account@project.iam.gserviceaccount.com"
         }
     }
+
+To install packages from Artifact Registry ensure `roles/artifactregistry.reader` role has been added to cloudbuild service account and the artifact registry keyring backend install has been enabled within the Dockerfile
+
+.. code:: python
+    
+    RUN pip install keyrings.google-artifactregistry-auth==1.1.1

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -105,7 +105,7 @@ class CloudRun(Backend):
             "steps": [
                 {
                     "name": "gcr.io/cloud-builders/docker",
-                    "args": ["build", "-t", registry, "."],
+                    "args": ["build", "--network=cloudbuild", "-t", registry, "."],
                 }
             ],
             "images": [registry],

--- a/goblet/write_files.py
+++ b/goblet/write_files.py
@@ -69,6 +69,8 @@ ENV APP_HOME /app
 WORKDIR $APP_HOME
 
 # Install dependencies.
+RUN pip install keyrings.google-artifactregistry-auth==1.1.1
+
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 

--- a/goblet/write_files.py
+++ b/goblet/write_files.py
@@ -68,9 +68,10 @@ FROM python:3.10-slim
 ENV APP_HOME /app
 WORKDIR $APP_HOME
 
-# Install dependencies.
-RUN pip install keyrings.google-artifactregistry-auth==1.1.1
+# install keyring backend to handle artifact registry authentication
+# RUN pip install keyrings.google-artifactregistry-auth==1.1.1
 
+# Install dependencies.
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
- exposes cloudbuild network to docker build container, will enable access to ADC credentials within cloudbuild steps: https://cloud.google.com/build/docs/build-config-file-schema#network
- adding keyrings to the Dockerfile will handle authentication and allow services to install packages directly from artifact registry: https://cloud.google.com/artifact-registry/docs/python/authentication#keyring (is required to be installed before packages can be installed)
 