### PR TITLE
Stage decorator and Resource Registration Refactor

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -771,6 +771,19 @@ For example the dev deployment will override the environment variable ``env`` wi
 You can view your current stages using ``goblet stage list``. To deploy or destroy a specific stage use the ``--stage`` or ``-s`` flag with the stage. You can also use the 
 environment variable ``STAGE``. For example ``goblet deploy -s dev``.
 
+You can limit what resources are deployed by stage by using the stage decorator. For example, the following will only
+be deployed and run when stage is dev.
+
+.. code:: python 
+
+    @app.route("/stage/dev")
+    @app.stage("dev")
+    def dev() -> str:
+        return "Only deployed and run when STAGE=dev"
+
+Note: You will need to set the STAGE as an environent variable on your backend as well. STAGE=dev in the above example. 
+
+Note: The stage will need to be specified as the bottom decorator for it to work properly. 
 
 API Gateway Backends
 ^^^^^^^^^^^^^^^^^^^^

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -38,9 +38,9 @@ class Goblet(Register_Handlers):
         self.backend_class = self.get_backend_and_check_versions(
             backend, client_versions or {}
         )
-        self.function_name = GConfig().function_name or function_name
+        self.function_name = GConfig(config).function_name or function_name
         self.labels = labels
-        self.backend = self.backend_class(self)
+        self.backend = self.backend_class(self, config=config)
 
         super(Goblet, self).__init__(
             function_name=self.function_name,
@@ -55,7 +55,7 @@ class Goblet(Register_Handlers):
         self.g = G()
 
         # Setup Local
-        module_name = GConfig().main_file or "main"
+        module_name = GConfig(config).main_file or "main"
         module_name = module_name.replace(".py", "")
         if local and sys.modules.get(module_name):
 

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import os
-from functools import wraps
+
 from goblet.backends.cloudfunctionv1 import CloudFunctionV1
 from goblet.backends.cloudfunctionv2 import CloudFunctionV2
 from goblet.backends.cloudrun import CloudRun

--- a/goblet/infrastructures/alerts.py
+++ b/goblet/infrastructures/alerts.py
@@ -22,12 +22,15 @@ class Alerts(Infrastructure):
     can_sync = True
     _gcp_deployed_alerts = {}
 
-    def register_alert(self, name, conditions, notification_channels=None, **kwargs):
+    def register(self, name, **kwargs):
+        kwargs = kwargs.get("kwargs", {})
+        conditions = kwargs.pop("conditions")
+        notification_channels = kwargs.pop("notification_channels", [])
         self.resource[f"{self.name}-{name}"] = {
             "name": f"{self.name}-{name}",
             "conditions": conditions,
-            "notification_channels": notification_channels or [],
-            "kwargs": kwargs.get("kwargs", {}),
+            "notification_channels": notification_channels,
+            "kwargs": kwargs,
         }
 
     @property

--- a/goblet/infrastructures/infrastructure.py
+++ b/goblet/infrastructures/infrastructure.py
@@ -22,6 +22,9 @@ class Infrastructure:
         self.resource = resource or {}
         self.config = GConfig(config=config)
 
+    def register(self, name, kwargs):
+        raise NotImplementedError("register")
+
     def deploy(self, config={}):
         raise NotImplementedError("deploy")
 

--- a/goblet/infrastructures/redis.py
+++ b/goblet/infrastructures/redis.py
@@ -10,7 +10,7 @@ class Redis(Infrastructure):
     resource_type = "redis"
     update_keys = ["displayName", "labels", "memorySizeGb", "replicaCount"]
 
-    def register_instance(self, name, kwargs):
+    def register(self, name, kwargs):
         self.resource = {"name": name}
 
     def deploy(self, config={}):

--- a/goblet/infrastructures/vpcconnector.py
+++ b/goblet/infrastructures/vpcconnector.py
@@ -11,7 +11,7 @@ class VPCConnector(Infrastructure):
 
     resource_type = "vpcconnector"
 
-    def register_connector(self, name, kwargs):
+    def register(self, name, kwargs):
         self.resource = {"name": name}
         vpcconnector_config = self.config.vpcconnector or {}
 

--- a/goblet/resources/eventarc.py
+++ b/goblet/resources/eventarc.py
@@ -34,7 +34,7 @@ class EventArc(Handler):
         )
         self.resources = resources or []
 
-    def register_trigger(self, name, func, kwargs):
+    def register(self, name, func, kwargs):
         event_filters = kwargs.get("event_filters")
         region = kwargs.get("kwargs", {}).get("region", get_default_location())
         if kwargs.get("topic"):

--- a/goblet/resources/handler.py
+++ b/goblet/resources/handler.py
@@ -27,6 +27,9 @@ class Handler:
         self.versioned_clients = versioned_clients or VersionedClients()
         self.cloudfunction = f"projects/{get_default_project()}/locations/{get_default_location()}/functions/{name}"
 
+    def register(self, name, func, kwargs):
+        raise NotImplementedError("register")
+
     def deploy(self, source=None, entrypoint=None, config={}):
         if self.resources and self.backend.resource_type not in self.valid_backends:
             log.info(

--- a/goblet/resources/http.py
+++ b/goblet/resources/http.py
@@ -18,7 +18,7 @@ class HTTP(Handler):
         )
         self.resources = resources or []
 
-    def register_http(self, func, kwargs):
+    def register(self, name, func, kwargs):
         self.resources.append({"func": func, "headers": kwargs.get("headers", {})})
 
     def __call__(self, request, context=None):

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -19,9 +19,9 @@ class Jobs(Handler):
     valid_backends = ["cloudrun"]
     can_sync = True
 
-    def register_job(self, name, func, kwargs):
+    def register(self, name, func, kwargs):
         task_id = kwargs["task_id"]
-        job_name = f"{self.name}-{name}"
+        job_name = f"{self.name}-{kwargs['name']}"
         if self.resources.get(job_name):
             self.resources[job_name][task_id] = {"func": func}
         else:

--- a/goblet/resources/pubsub.py
+++ b/goblet/resources/pubsub.py
@@ -28,7 +28,7 @@ class PubSub(Handler):
     resource_type = "pubsub"
     can_sync = True
 
-    def register_topic(self, name, func, kwargs):
+    def register(self, name, func, kwargs):
         topic = kwargs["topic"]
         kwargs = kwargs.pop("kwargs")
         attributes = kwargs.get("attributes", {})

--- a/goblet/resources/routes.py
+++ b/goblet/resources/routes.py
@@ -58,7 +58,7 @@ class ApiGateway(Handler):
         # ([a-z0-9-.]+) for api gateway name
         return name.replace("_", "-")
 
-    def register_route(self, name, func, kwargs):
+    def register(self, name, func, kwargs):
         path = kwargs.pop("path")
         methods = kwargs.pop("methods")
         kwargs = kwargs.pop("kwargs")

--- a/goblet/resources/scheduler.py
+++ b/goblet/resources/scheduler.py
@@ -23,7 +23,7 @@ class Scheduler(Handler):
     valid_backends = ["cloudfunction", "cloudfunctionv2", "cloudrun"]
     can_sync = True
 
-    def register_job(self, name, func, kwargs):
+    def register(self, name, func, kwargs):
         schedule = kwargs["schedule"]
         timezone = kwargs["timezone"]
         kwargs = kwargs.pop("kwargs")

--- a/goblet/resources/storage.py
+++ b/goblet/resources/storage.py
@@ -45,7 +45,7 @@ class Storage(Handler):
                 f"/calling/storage for more information. "
             )
 
-    def register_bucket(self, name, func, kwargs):
+    def register(self, name, func, kwargs):
         bucket_name = kwargs["bucket"]
         event_type = kwargs["event_type"]
         self.validate_event_type(event_type)

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -142,6 +142,28 @@ class TestDecoraters:
 
         assert app(mock_request, {}) == "test after request"
 
+    def test_stages(self, monkeypatch):
+        monkeypatch.setenv("STAGE", "TEST2")
+
+        app = Goblet("test", config={"stages": {"TEST2": {}}})
+
+        @app.route("/test")
+        @app.stage("TEST")
+        def dummy_function():
+            return "test"
+
+        @app.route("/test2")
+        @app.stage("TEST2")
+        def dummy_function():
+            return "test"
+
+        @app.route("/test3")
+        @app.stage("TEST2")
+        def dummy_function():
+            return "test"
+
+        assert len(app.handlers["route"].resources) == 2
+
 
 # Causes tests to fail
 # class TestGoblet:

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -154,12 +154,12 @@ class TestDecoraters:
 
         @app.route("/test2")
         @app.stage("TEST2")
-        def dummy_function():
+        def dummy_function2():
             return "test"
 
         @app.route("/test3")
         @app.stage("TEST2")
-        def dummy_function():
+        def dummy_function3():
             return "test"
 
         assert len(app.handlers["route"].resources) == 2

--- a/goblet/tests/test_deployer.py
+++ b/goblet/tests/test_deployer.py
@@ -35,7 +35,7 @@ class TestDeployer:
         app = Goblet(function_name="goblet-test-http-v2", backend="cloudfunctionv2")
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.deploy(
             skip_resources=True,

--- a/goblet/tests/test_jobs.py
+++ b/goblet/tests/test_jobs.py
@@ -85,7 +85,7 @@ class TestJobs:
         jobs = Jobs(
             goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
         )
-        jobs.register("test", None, {"task_id": 0})
+        jobs.register("test", None, {"task_id": 0, "name": "test"})
         jobs._deploy()
 
         responses = get_responses("job-deploy")
@@ -126,7 +126,7 @@ class TestJobs:
 
         goblet_name = "test-job"
         jobs = Jobs(goblet_name, CloudFunctionV1(Goblet(function_name="test-job")))
-        jobs.register("test2", None, {"task_id": 0})
+        jobs.register("test2", None, {"task_id": 0, "name": "test"})
         jobs.sync()
 
         responses = get_responses("job-sync")
@@ -141,7 +141,7 @@ class TestJobs:
 
         goblet_name = "goblet-test"
         jobs = Jobs(goblet_name, CloudFunctionV1(Goblet(function_name=goblet_name)))
-        jobs.register("test", None, {"task_id": 0})
+        jobs.register("test", None, {"task_id": 0, "name": "test"})
         jobs.destroy()
 
         responses = get_responses("job-destroy")

--- a/goblet/tests/test_jobs.py
+++ b/goblet/tests/test_jobs.py
@@ -85,7 +85,7 @@ class TestJobs:
         jobs = Jobs(
             goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
         )
-        jobs.register_job("test", None, {"task_id": 0})
+        jobs.register("test", None, {"task_id": 0})
         jobs._deploy()
 
         responses = get_responses("job-deploy")
@@ -126,7 +126,7 @@ class TestJobs:
 
         goblet_name = "test-job"
         jobs = Jobs(goblet_name, CloudFunctionV1(Goblet(function_name="test-job")))
-        jobs.register_job("test2", None, {"task_id": 0})
+        jobs.register("test2", None, {"task_id": 0})
         jobs.sync()
 
         responses = get_responses("job-sync")
@@ -141,7 +141,7 @@ class TestJobs:
 
         goblet_name = "goblet-test"
         jobs = Jobs(goblet_name, CloudFunctionV1(Goblet(function_name=goblet_name)))
-        jobs.register_job("test", None, {"task_id": 0})
+        jobs.register("test", None, {"task_id": 0})
         jobs.destroy()
 
         responses = get_responses("job-destroy")

--- a/goblet/tests/test_pubsub.py
+++ b/goblet/tests/test_pubsub.py
@@ -311,7 +311,7 @@ class TestPubSub:
         monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
 
         pubsub = PubSub("goblet", backend=CloudRun(Goblet(backend="cloudrun")))
-        pubsub.register_topic("test", None, kwargs={"topic": "test", "kwargs": {}})
+        pubsub.register("test", None, kwargs={"topic": "test", "kwargs": {}})
 
         cloudrun_url = "https://goblet-12345.a.run.app"
         service_account = "SERVICE_ACCOUNT@developer.gserviceaccount.com"
@@ -360,7 +360,7 @@ class TestPubSub:
             "test-cross-project",
             backend=CloudFunctionV1(Goblet()),
         )
-        pubsub.register_topic(
+        pubsub.register(
             "test",
             None,
             kwargs={"topic": "test", "kwargs": {"project": "goblet-cross-project"}},

--- a/goblet/tests/test_redis.py
+++ b/goblet/tests/test_redis.py
@@ -99,7 +99,7 @@ class TestRedis:
         app = Goblet(function_name="goblet-example", backend="cloudrun")
         app.redis(name="redis-test")
 
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.deploy(
             skip_resources=True,
@@ -147,7 +147,7 @@ class TestRedis:
         app = Goblet(function_name="goblet-example", backend="cloudfunction")
         app.redis(name="redis-test")
 
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.deploy(
             skip_resources=True,
@@ -185,7 +185,7 @@ class TestRedis:
 
         app = Goblet(function_name="goblet-example", backend="cloudfunctionv2")
         app.redis(name="redis-test")
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.deploy(
             skip_resources=True,

--- a/goblet/tests/test_scheduler.py
+++ b/goblet/tests/test_scheduler.py
@@ -124,7 +124,7 @@ class TestScheduler:
 
         goblet_name = "goblet_example"
         scheduler = Scheduler(goblet_name, backend=CloudFunctionV1(Goblet()))
-        scheduler.register_job(
+        scheduler.register(
             "test-job",
             None,
             kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
@@ -151,7 +151,7 @@ class TestScheduler:
         scheduler = Scheduler("goblet", backend=CloudRun(Goblet(backend="cloudrun")))
         cloudrun_url = "https://goblet-12345.a.run.app"
         service_account = "SERVICE_ACCOUNT@developer.gserviceaccount.com"
-        scheduler.register_job(
+        scheduler.register(
             "test-job",
             None,
             kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
@@ -180,12 +180,12 @@ class TestScheduler:
         scheduler = Scheduler(
             goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
         )
-        scheduler.register_job(
+        scheduler.register(
             "test-job",
             None,
             kwargs={"schedule": "* * 1 * *", "timezone": "UTC", "kwargs": {}},
         )
-        scheduler.register_job(
+        scheduler.register(
             "test-job",
             None,
             kwargs={
@@ -194,7 +194,7 @@ class TestScheduler:
                 "kwargs": {"httpMethod": "POST"},
             },
         )
-        scheduler.register_job(
+        scheduler.register(
             "test-job",
             None,
             kwargs={
@@ -240,7 +240,7 @@ class TestScheduler:
         scheduler = Scheduler(
             goblet_name, backend=CloudFunctionV1(Goblet(function_name=goblet_name))
         )
-        scheduler.register_job(
+        scheduler.register(
             "test-job",
             None,
             kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},
@@ -260,7 +260,7 @@ class TestScheduler:
 
         goblet_name = "goblet"
         scheduler = Scheduler(goblet_name, backend=CloudFunctionV1(Goblet()))
-        scheduler.register_job(
+        scheduler.register(
             "scheduled_job",
             None,
             kwargs={"schedule": "* * * * *", "timezone": "UTC", "kwargs": {}},

--- a/goblet/tests/test_vpcconnector.py
+++ b/goblet/tests/test_vpcconnector.py
@@ -78,7 +78,7 @@ class TestVPCConnector:
         )
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.vpcconnector(name="vpc-test")
         # app.deploy(
@@ -112,7 +112,7 @@ class TestVPCConnector:
         )
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.vpcconnector(name="vpc-test")
         # app.deploy(
@@ -144,7 +144,7 @@ class TestVPCConnector:
         )
         setattr(app, "entrypoint", "app")
 
-        app.handlers["http"].register_http(dummy_function, {})
+        app.handlers["http"].register("", dummy_function, {})
 
         app.vpcconnector(name="vpc-test")
         # app.deploy(


### PR DESCRIPTION
You can limit what resources are deployed by stage by using the stage decorator (closes #247 ). For example, the following will only
be deployed and run when stage is dev.

```
    @app.route("/stage/dev")
    @app.stage("dev")
    def dev() -> str:
        return "Only deployed and run when STAGE=dev"
  
```

Refactors resource registration 