### PR TITLE
Local support for --set-env secrets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: psf/black@stable
         with:
           src: "./goblet"
+          version: "23.1.0"
 
   Test:
     runs-on: ubuntu-latest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,4 @@ coverage
 flake8
 pytest
 requests-mock
+black==23.1.0

--- a/examples/main.py
+++ b/examples/main.py
@@ -1,6 +1,10 @@
 from urllib import request
 from goblet import Goblet, jsonify, Response, goblet_entrypoint
-from goblet.infrastructures.alerts import MetricCondition,LogMatchCondition,CustomMetricCondition
+from goblet.infrastructures.alerts import (
+    MetricCondition,
+    LogMatchCondition,
+    CustomMetricCondition,
+)
 import logging
 
 app = Goblet(function_name="goblet_example", region="us-central-1")
@@ -282,12 +286,14 @@ def job1_task2(id):
     app.log.info(f"different task for job...{id}")
     return "200"
 
+
 # Example BQ Remote Function
 # Called in BQ with the following sql: SELECT `PROJECT.DATASET.math_example_multiply(x,y,z)` from DATASET.table
 @app.bqremotefunction(dataset_id="DATASET")
 def multiply(x: int, y: int, z: int) -> int:
     w = x * y * z
     return w
+
 
 # Example Redis Instance
 app.redis("redis-test")
@@ -296,7 +302,16 @@ app.redis("redis-test")
 app.vpcconnector("vpc-conn-test")
 
 # Example Metric Alert for the cloudfunction metric execution_count with a threshold of 10
-app.alert("metric",conditions=[MetricCondition("test", metric="cloudfunctions.googleapis.com/function/execution_count", value=10)])
+app.alert(
+    "metric",
+    conditions=[
+        MetricCondition(
+            "test",
+            metric="cloudfunctions.googleapis.com/function/execution_count",
+            value=10,
+        )
+    ],
+)
 
 # Example Metric Alert for the cloudfunction metric execution_times with a Delta type with a threshold of 1000 ms
 app.alert(
@@ -318,7 +333,16 @@ app.alert(
 )
 
 # Example Log Match metric that will trigger an incendent off of any Error logs
-app.alert("error",conditions=[LogMatchCondition("error", "severity>=ERROR")])
+app.alert("error", conditions=[LogMatchCondition("error", "severity>=ERROR")])
 
 # Example Metric Alert that creates a custom metric for severe errors with http code in the 500's and creates an alert with a threshold of 10
-app.alert("custom",conditions=[CustomMetricCondition("custom", metric_filter='severity=(ERROR OR CRITICAL OR ALERT OR EMERGENCY) httpRequest.status=(500 OR 501 OR 502 OR 503 OR 504)', value=10)])
+app.alert(
+    "custom",
+    conditions=[
+        CustomMetricCondition(
+            "custom",
+            metric_filter="severity=(ERROR OR CRITICAL OR ALERT OR EMERGENCY) httpRequest.status=(500 OR 501 OR 502 OR 503 OR 504)",
+            value=10,
+        )
+    ],
+)

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 10, 1)
+VERSION = (0, 10, 2)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/backends/cloudfunctionv1.py
+++ b/goblet/backends/cloudfunctionv1.py
@@ -1,5 +1,5 @@
 from requests import request
-
+import base64
 
 from goblet.backends.backend import Backend
 from goblet.client import VersionedClients, get_default_location, get_default_project
@@ -115,6 +115,32 @@ class CloudFunctionV1(Backend):
         )
 
     def get_environment_vars(self):
-        return self.config.config.get("cloudfunction", {}).get(
+        env_dict = self.config.config.get("cloudfunction", {}).get(
             "environmentVariables", {}
         )
+
+        versioned_clients = VersionedClients(self.app.client_versions)
+        for secret in self.config.config.get("cloudfunction", {}).get(
+            "secretEnvironmentVariables", []
+        ):
+            try:
+                secret_name = secret["secret"]
+                version = secret["version"]
+
+                resp = versioned_clients.secretmanager.execute(
+                    "access",
+                    parent_key="name",
+                    parent_schema="projects/{project_id}/secrets/"
+                    + secret_name
+                    + "/versions/"
+                    + version,
+                )
+                env_dict[secret["key"]] = base64.b64decode(
+                    resp["payload"]["data"]
+                ).decode()
+            except Exception:
+                self.log.info(
+                    f"Unable to get secret {secret['key']} and set environment variable. Skipping..."
+                )
+
+        return env_dict

--- a/goblet/backends/cloudfunctionv1.py
+++ b/goblet/backends/cloudfunctionv1.py
@@ -138,9 +138,9 @@ class CloudFunctionV1(Backend):
                 env_dict[secret["key"]] = base64.b64decode(
                     resp["payload"]["data"]
                 ).decode()
-            except Exception:
+            except Exception as e:
                 self.log.info(
-                    f"Unable to get secret {secret['key']} and set environment variable. Skipping..."
+                    f"Unable to get secret {secret['key']} and set environment variable with error {str(e)}. Skipping..."
                 )
 
         return env_dict

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -227,7 +227,7 @@ class CloudRun(Backend):
                     env_dict[env_item["name"]] = base64.b64decode(
                         resp["payload"]["data"]
                     ).decode()
-                except Exception as e:
+                except Exception:
                     self.log.info(
                         f"Unable to get secret {env_item['name']} and set environment variable. Skipping..."
                     )

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -227,7 +227,10 @@ class CloudRun(Backend):
                     env_dict[env_item["name"]] = base64.b64decode(
                         resp["payload"]["data"]
                     ).decode()
-                except Exception:
+                except Exception as e:
+                    self.log.info(
+                        f"Error retrieving secret {env_item['name']} with error {str(e)}"
+                    )
                     self.log.info(
                         f"Unable to get secret {env_item['name']} and set environment variable. Skipping..."
                     )

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -337,7 +337,8 @@ def job():
 )
 @click.argument("task_id", envvar="CLOUD_RUN_TASK_INDEX", default="0")
 @click.option("--set-env", "set_env", is_flag=True)
-def run_job(name, task_id, set_env):
+@click.option("-s", "--stage", "stage", envvar="STAGE")
+def run_job(name, task_id, set_env, stage):
     """
     Run a Cloudrun Job in local environment.
     """
@@ -345,6 +346,8 @@ def run_job(name, task_id, set_env):
     
     try:
         app = get_goblet_app(GConfig().main_file or "main.py")
+        if stage:
+            os.environ["STAGE"] = stage
         if set_env:
             env_dict = app.backend.get_environment_vars()
             for k, v in env_dict.items():

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -336,13 +336,19 @@ def job():
     "name",
 )
 @click.argument("task_id", envvar="CLOUD_RUN_TASK_INDEX", default="0")
-def run_job(name, task_id):
+@click.option("--set-env", "set_env", is_flag=True)
+def run_job(name, task_id, set_env):
     """
     Run a Cloudrun Job in local environment.
     """
     os.environ["CLOUD_RUN_TASK_INDEX"] = task_id
+    
     try:
         app = get_goblet_app(GConfig().main_file or "main.py")
+        if set_env:
+            env_dict = app.backend.get_environment_vars()
+            for k, v in env_dict.items():
+                os.environ[k] = v
         app(name, int(task_id))
 
     except FileNotFoundError as not_found:

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -343,7 +343,7 @@ def run_job(name, task_id, set_env, stage):
     Run a Cloudrun Job in local environment.
     """
     os.environ["CLOUD_RUN_TASK_INDEX"] = task_id
-    
+
     try:
         app = get_goblet_app(GConfig().main_file or "main.py")
         if stage:

--- a/goblet/client.py
+++ b/goblet/client.py
@@ -23,6 +23,7 @@ DEFAULT_CLIENT_VERSIONS = {
     "vpcaccess": "v1",
     "bigquery": "v2",
     "bigqueryconnection": "v1",
+    "secretmanager": "v1",
 }
 
 
@@ -367,5 +368,14 @@ class VersionedClients:
             "logging",
             self.client_versions.get("logging", "v2"),
             calls="projects.metrics",
+            parent_schema="projects/{project_id}",
+        )
+
+    @property
+    def secretmanager(self):
+        return Client(
+            "secretmanager",
+            self.client_versions.get("secretmanager", "v1"),
+            calls="projects.secrets.versions",
             parent_schema="projects/{project_id}",
         )

--- a/goblet/config.py
+++ b/goblet/config.py
@@ -9,7 +9,8 @@ log.setLevel(logging.INFO)
 
 class GConfig:
     """Config class used to get variables from config.json or from the environment. If stage is set as an environment level
-    if will parse the corresponding section in config.json and return those config values"""
+    if will parse the corresponding section in config.json and return those config values
+    """
 
     def __init__(self, config=None, stage=None):
         self.config = self.get_g_config()

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -78,7 +78,8 @@ class DecoratorAPI:
 
     def middleware(self, event_type="all"):
         """Middleware functions that are called before events for preprocessing.
-        This is deprecated and will be removed in the future. Use before_request instead"""
+        This is deprecated and will be removed in the future. Use before_request instead
+        """
         warn(
             "Middleware method is deprecated. Use before_request instead",
             DeprecationWarning,
@@ -224,7 +225,6 @@ class DecoratorAPI:
         return _register_handler
 
     def _register_handler(self, handler_type, name, func, kwargs, options=None):
-
         name = kwargs.get("kwargs", {}).get("name") or name
         self.handlers[handler_type].register(name=name, func=func, kwargs=kwargs)
 

--- a/goblet/infrastructures/alerts.py
+++ b/goblet/infrastructures/alerts.py
@@ -154,7 +154,8 @@ class Alerts(Infrastructure):
 class AlertCondition:
     """Base class for Alert Conditions. Only one of type threshold, absense, log_match, or MQL can be specified per condition.
     The method format_filter_or_query is used to inject values from the backend into the filters and conditions. These can be injected into
-    custom filters as well. Currently monitoring_type,resource_name, and monitoring_label_key are supported."""
+    custom filters as well. Currently monitoring_type,resource_name, and monitoring_label_key are supported.
+    """
 
     def __init__(
         self, name, threshold=None, absence=None, log_match=None, MQL=None

--- a/goblet/infrastructures/vpcconnector.py
+++ b/goblet/infrastructures/vpcconnector.py
@@ -8,7 +8,6 @@ log.setLevel(logging.INFO)
 
 
 class VPCConnector(Infrastructure):
-
     resource_type = "vpcconnector"
 
     def register(self, name, kwargs):

--- a/goblet/resources/jobs.py
+++ b/goblet/resources/jobs.py
@@ -54,7 +54,6 @@ class Jobs(Handler):
 
         log.info("deploying cloudrun jobs......")
         for job_name, job in self.resources.items():
-
             container = {**(gconfig.job_container or {})}
             annotations = {**(gconfig.job_annotations or {})}
             container["image"] = artifact

--- a/goblet/resources/plugins/pydantic.py
+++ b/goblet/resources/plugins/pydantic.py
@@ -27,7 +27,7 @@ class PydanticPlugin(BasePlugin):
         org_schema = model.schema(ref_template="#/definitions/{model}")
         schema = copy.deepcopy(org_schema)
         if "definitions" in schema:
-            for (k, v) in schema["definitions"].items():
+            for k, v in schema["definitions"].items():
                 if k not in self.spec.components.schemas:
                     self.spec.components.schema(k, v)
             del schema["definitions"]

--- a/goblet/revision.py
+++ b/goblet/revision.py
@@ -57,7 +57,6 @@ class RevisionSpec:
             newPercent = math.ceil(traffics["percent"] * trafficQuotient)
 
             if traffics["type"] == "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST":
-
                 newTraffic = {
                     "type": "TRAFFIC_TARGET_ALLOCATION_TYPE_REVISION",
                     "revision": serviceConfig["latestReadyRevision"].rpartition("/")[

--- a/goblet/tests/data/http/get-secrets/get-v1-projects-goblet-secrets-TESTSECRET-versions-1-access_1.json
+++ b/goblet/tests/data/http/get-secrets/get-v1-projects-goblet-secrets-TESTSECRET-versions-1-access_1.json
@@ -1,0 +1,10 @@
+{
+  "headers": {},
+  "body": {
+    "name": "projects/goblet/secrets/TESTSECRET/versions/1",
+    "payload": {
+      "data": "dGVzdHRlc3R0ZXN0",
+      "dataCrc32c": "81533553"
+    }
+  }
+}

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -100,7 +100,6 @@ class TestDecoraters:
         ]
 
     def test_is_http(self):
-
         app1 = Goblet("test1")
         app2 = Goblet("test2")
         app3 = Goblet("test3")

--- a/goblet/tests/test_backend.py
+++ b/goblet/tests/test_backend.py
@@ -41,3 +41,47 @@ class TestBackend:
         backend = CloudRun(Goblet(), config=test_env)
 
         assert backend.get_environment_vars() == {"TEST": "VALUE"}
+
+    def test_get_env_cloudrun_secret(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("GOBLET_TEST_NAME", "get-secrets")
+        monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
+
+        test_env = {
+            "cloudrun_container": {
+                "env": [
+                    {
+                        "name": "TESTSECRET",
+                        "valueSource": {
+                            "secretKeyRef": {"secret": "TESTSECRET", "version": "1"}
+                        },
+                    }
+                ]
+            }
+        }
+        backend = CloudRun(Goblet(), config=test_env)
+
+        assert backend.get_environment_vars() == {"TESTSECRET": "testtesttest"}
+
+    def test_get_env_cloudfunction_secret(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("GOBLET_TEST_NAME", "get-secrets")
+        monkeypatch.setenv("GOBLET_HTTP_TEST", "REPLAY")
+
+        test_env = {
+            "cloudfunction": {
+                "secretEnvironmentVariables": [
+                    {
+                        "name": "TESTSECRET",
+                        "valueSource": {
+                            "secretKeyRef": {"secret": "TESTSECRET", "version": "1"}
+                        },
+                    }
+                ]
+            }
+        }
+        backend = CloudRun(Goblet(), config=test_env)
+
+        assert backend.get_environment_vars() == {"TESTSECRET": "testtesttest"}

--- a/goblet/tests/test_backend.py
+++ b/goblet/tests/test_backend.py
@@ -18,14 +18,12 @@ class TestBackend:
         assert "build" in backend.zip_config["exclude"]
 
     def test_get_env_cloudfunction_v1(self):
-
         test_env = {"cloudfunction": {"environmentVariables": {"TEST": "VALUE"}}}
         backend = CloudFunctionV1(Goblet(), config=test_env)
 
         assert backend.get_environment_vars() == {"TEST": "VALUE"}
 
     def test_get_env_cloudfunction_v2(self):
-
         test_env = {
             "cloudfunction": {
                 "serviceConfig": {"environmentVariables": {"TEST": "VALUE"}}
@@ -36,7 +34,6 @@ class TestBackend:
         assert backend.get_environment_vars() == {"TEST": "VALUE"}
 
     def test_get_env_cloudrun(self):
-
         test_env = {"cloudrun_container": {"env": [{"name": "TEST", "value": "VALUE"}]}}
         backend = CloudRun(Goblet(), config=test_env)
 

--- a/goblet/tests/test_backend.py
+++ b/goblet/tests/test_backend.py
@@ -70,15 +70,10 @@ class TestBackend:
         test_env = {
             "cloudfunction": {
                 "secretEnvironmentVariables": [
-                    {
-                        "name": "TESTSECRET",
-                        "valueSource": {
-                            "secretKeyRef": {"secret": "TESTSECRET", "version": "1"}
-                        },
-                    }
+                    {"key": "TESTSECRET", "secret": "TESTSECRET", "version": "1"},
                 ]
             }
         }
-        backend = CloudRun(Goblet(), config=test_env)
+        backend = CloudFunctionV1(Goblet(), config=test_env)
 
         assert backend.get_environment_vars() == {"TESTSECRET": "testtesttest"}

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -232,7 +232,6 @@ class TestRoutes:
         assert gw.deploy() is None
 
     def test_deploy_routes_type_cloudrun_with_incorrect_backend(self, monkeypatch):
-
         ApiGateway(
             name="test",
             routes_type="cloudrun",


### PR DESCRIPTION
* local support for `--set-env` secrets (#309 ). Goblet will now get the secret from secrets manager and set as env variable. If permission is not granted, then the secret will be skipped locally. 
* local support for `--set-env` and `stage` for cloudrun jobs (#312 ) 