### PR TITLE
Pass through current_request to added api's

### DIFF
--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 10, 3)
+VERSION = (0, 10, 4)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -243,6 +243,8 @@ class DecoratorAPI:
 class Register_Handlers(DecoratorAPI):
     """Core Goblet logic. App entrypoint is the __call__ function which routes the request to the corresonding handler class"""
 
+    app_list = []
+
     def __init__(
         self,
         function_name,
@@ -318,6 +320,12 @@ class Register_Handlers(DecoratorAPI):
         """Goblet entrypoint"""
         self.current_request = request
         self.request_context = context
+
+        # set var's for added apps
+        for added_app in self.app_list:
+            added_app.current_request = request
+            added_app.request_context = context
+
         event_type = self.get_event_type(request, context)
         # call before request middleware
         request = self._call_middleware(request, event_type, before_or_after="before")
@@ -350,6 +358,7 @@ class Register_Handlers(DecoratorAPI):
         return response
 
     def __add__(self, other):
+        self.app_list.append(other)
         for handler in self.handlers:
             self.handlers[handler] += other.handlers[handler]
         return self

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -75,6 +75,24 @@ class TestDecoraters:
             "dummy_function2",
         ]
 
+    def test_add_current_request(self):
+        app1 = Goblet("test")
+        app2 = Goblet("test")
+
+        @app2.route("/app2")
+        def dummy_function():
+            return app2.current_request.json["test"]
+
+        app1 + app2
+
+        mock_request = Mock()
+        mock_request.path = "/app2"
+        mock_request.method = "GET"
+        mock_request.headers = {}
+        mock_request.json = {"test": "value"}
+
+        assert app1(mock_request, {}) == "value"
+
     def test_combine(self):
         app1 = Goblet("test")
         app2 = Goblet("test")


### PR DESCRIPTION
* Correctly pass through current_request and request_context (closes #257 )

```
app = Goblet(function_name="1")
app2  = Goblet(function_name="2")
app = app + app2

@app2.route()
def app2_route():
    app2.current_request
```