### PR TITLE
[Bugfix] Support for list request body

### DIFF
--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -447,6 +447,7 @@ class Register_Handlers(DecoratorAPI):
             return "eventarc"
         if (
             request.is_json
+            and isinstance(request.json, dict)
             and request.json.get("userDefinedContext")
             and request.json["userDefinedContext"].get("X-Goblet-Name")
         ):
@@ -454,6 +455,7 @@ class Register_Handlers(DecoratorAPI):
         if (
             request.is_json
             and request.get_json(silent=True)
+            and isinstance(request.json, dict)
             and request.json.get("subscription")
             and request.json.get("message")
         ):

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -105,6 +105,21 @@ class TestRoutes:
         assert mock.call_count == 1
         mock_param.assert_called_once_with("param")
 
+    def test_call_route_list_request_body(self):
+        app = Goblet(function_name="goblet_example")
+        mock = Mock()
+
+        app.route("/test", methods=["POST"])(mock_dummy_function(mock))
+
+        mock_event1 = Mock()
+        mock_event1.path = "/test"
+        mock_event1.method = "POST"
+        mock_event1.headers = {}
+        mock_event1.json = [{"field": "value"}, {"field": "value"}]
+
+        app(mock_event1, None)
+        assert mock.call_count == 1
+
     def test_cors(self):
         app = Goblet(function_name="goblet_cors")
         app2 = Goblet(


### PR DESCRIPTION
*  Support for list request body(closes #347 )

support request body 
```mock_event1.json = [{"field": "value"}, {"field": "value"}]```