### PR TITLE
[cli] check or enable gcp service apis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install Linter
         run: |
           python -m pip install --upgrade pip
@@ -33,7 +33,7 @@ jobs:
     needs: Lint
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
     name: Test Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -114,7 +114,7 @@ class Goblet(Register_Handlers):
                 log.info(f"destroying {k}")
                 v.destroy()
 
-    def services(self, enable=False):
+    def check_or_enable_services(self, enable=False):
         self.backend.check_or_enable_service(enable)
         for _, v in self.handlers.items():
             v.check_or_enable_service(enable)

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -115,11 +115,11 @@ class Goblet(Register_Handlers):
                 v.destroy()
 
     def check_or_enable_services(self, enable=False):
-        self.backend.check_or_enable_service(enable)
+        self.backend._check_or_enable_service(enable)
         for _, v in self.handlers.items():
-            v.check_or_enable_service(enable)
+            v._check_or_enable_service(enable)
         for _, v in self.infrastructure.items():
-            v.check_or_enable_service(enable)
+            v._check_or_enable_service(enable)
         return None
 
     def package(self):

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -114,6 +114,14 @@ class Goblet(Register_Handlers):
                 log.info(f"destroying {k}")
                 v.destroy()
 
+    def services(self, enable=False):
+        self.backend.check_or_enable_service(enable)
+        for _, v in self.handlers.items():
+            v.check_or_enable_service(enable)
+        for _, v in self.infrastructure.items():
+            v.check_or_enable_service(enable)
+        return None
+
     def package(self):
         self.backend.zip()
 

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -183,5 +183,5 @@ class Backend:
     def get_environment_vars(self):
         raise NotImplementedError("get_environment_vars")
 
-    def check_or_enable_service(self, enable=False):
+    def _check_or_enable_service(self, enable=False):
         return check_or_enable_service(self.required_apis, enable)

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -11,6 +11,7 @@ from googleapiclient.errors import HttpError
 
 from goblet.config import GConfig
 from goblet.utils import get_g_dir, checksum, build_stage_config
+from goblet.common_cloud_actions import check_or_enable_service
 
 
 class Backend:
@@ -22,6 +23,7 @@ class Backend:
     config_key = ""
     monitoring_type = ""
     monitoring_label_key = ""
+    required_apis = []
 
     def __init__(self, app, client, func_path, config={}):
         self.app = app
@@ -180,3 +182,6 @@ class Backend:
 
     def get_environment_vars(self):
         raise NotImplementedError("get_environment_vars")
+
+    def check_or_enable_service(self, enable=False):
+        return check_or_enable_service(self.required_apis, enable)

--- a/goblet/backends/cloudfunctionv1.py
+++ b/goblet/backends/cloudfunctionv1.py
@@ -19,6 +19,7 @@ class CloudFunctionV1(Backend):
     config_key = "cloudfunction"
     monitoring_type = "cloud_function"
     monitoring_label_key = "function_name"
+    required_apis = ["cloudfunctions", "secretmanager"]
 
     def __init__(self, app, config={}):
         self.client = VersionedClients(app.client_versions).cloudfunctions

--- a/goblet/backends/cloudfunctionv2.py
+++ b/goblet/backends/cloudfunctionv2.py
@@ -22,6 +22,7 @@ class CloudFunctionV2(Backend):
     config_key = "cloudfunction"
     monitoring_type = "cloud_function"
     monitoring_label_key = "function_name"
+    required_apis = ["cloudfunctions"]
 
     def __init__(self, app, config={}):
         self.client = VersionedClients(app.client_versions).cloudfunctions

--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -31,6 +31,7 @@ class CloudRun(Backend):
     supported_versions = ["v2"]
     monitoring_type = "cloud_run_revision"
     monitoring_label_key = "service_name"
+    required_apis = ["run", "cloudbuild", "cloudfunctions"]
 
     def __init__(self, app, config={}):
         self.client = VersionedClients(app.client_versions).run

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -368,5 +368,60 @@ def run_job(name, task_id, set_env, stage):
         sys.exit(1)
 
 
+@main.group()
+def services():
+    """check and enable gcp service apis for your gcp project"""
+    pass
+
+
+@services.command(name="check")
+@click.option("-p", "--project", "project", envvar="GOOGLE_PROJECT")
+@click.option("-s", "--stage", "stage", envvar="STAGE")
+def check_gcp_services(project, stage):
+    """check status of gcp service apis"""
+    os.environ["X-GOBLET-DEPLOY"] = "true"
+    try:
+        _project = project or get_default_project()
+        if not _project:
+            click.echo(
+                "Project not found. Set --project flag or add to gcloud by using gcloud config set project PROJECT"
+            )
+        os.environ["GOOGLE_PROJECT"] = _project
+        if stage:
+            os.environ["STAGE"] = stage
+        app = get_goblet_app(GConfig().main_file or "main.py")
+        app.services()
+    except FileNotFoundError as not_found:
+        click.echo(
+            f"Missing {not_found.filename}. Make sure you are in the correct directory and this file exists"
+        )
+        sys.exit(1)
+
+
+@services.command(name="enable")
+@click.option("-p", "--project", "project", envvar="GOOGLE_PROJECT")
+@click.option("-s", "--stage", "stage", envvar="STAGE")
+def enable_gcp_services(project, stage):
+    """enable gcp service apis"""
+    os.environ["X-GOBLET-DEPLOY"] = "true"
+    try:
+        _project = project or get_default_project()
+        if not _project:
+            click.echo(
+                "Project not found. Set --project flag or add to gcloud by using gcloud config set project PROJECT"
+            )
+        os.environ["GOOGLE_PROJECT"] = _project
+        if stage:
+            os.environ["STAGE"] = stage
+        app = get_goblet_app(GConfig().main_file or "main.py")
+        app.services(enable=True)
+
+    except FileNotFoundError as not_found:
+        click.echo(
+            f"Missing {not_found.filename}. Make sure you are in the correct directory and this file exists"
+        )
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     main()  # pylint: disable=no-value-for-parameter

--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -390,7 +390,7 @@ def check_gcp_services(project, stage):
         if stage:
             os.environ["STAGE"] = stage
         app = get_goblet_app(GConfig().main_file or "main.py")
-        app.services()
+        app.check_or_enable_services()
     except FileNotFoundError as not_found:
         click.echo(
             f"Missing {not_found.filename}. Make sure you are in the correct directory and this file exists"
@@ -414,7 +414,7 @@ def enable_gcp_services(project, stage):
         if stage:
             os.environ["STAGE"] = stage
         app = get_goblet_app(GConfig().main_file or "main.py")
-        app.services(enable=True)
+        app.check_or_enable_services(enable=True)
 
     except FileNotFoundError as not_found:
         click.echo(

--- a/goblet/client.py
+++ b/goblet/client.py
@@ -18,6 +18,7 @@ DEFAULT_CLIENT_VERSIONS = {
     "bigqueryconnection": "v1",
     "secretmanager": "v1",
     "cloudtasks": "v2",
+    "serviceusage": "v1",
 }
 
 
@@ -212,5 +213,14 @@ class VersionedClients:
             "secretmanager",
             self.client_versions.get("secretmanager", "v1"),
             calls="projects.secrets.versions",
+            parent_schema="projects/{project_id}",
+        )
+
+    @property
+    def service_usage(self):
+        return Client(
+            "serviceusage",
+            self.client_versions.get("serviceusage", "v1"),
+            calls="services",
             parent_schema="projects/{project_id}",
         )

--- a/goblet/common_cloud_actions.py
+++ b/goblet/common_cloud_actions.py
@@ -18,12 +18,15 @@ from goblet_gcp_client.client import (
 )
 from goblet.errors import GobletError
 from goblet.utils import get_python_runtime
+from typing import List
 
 log = logging.getLogger("goblet.deployer")
 log.setLevel(logging.INFO)
 
 
-def check_or_enable_service(resources, enable=False):
+def check_or_enable_service(resources: List[str], enable: bool = False):
+    if len(resources) == 0:
+        return
     client = VersionedClients().service_usage
     if enable:
         resp = client.execute(

--- a/goblet/common_cloud_actions.py
+++ b/goblet/common_cloud_actions.py
@@ -23,7 +23,7 @@ log = logging.getLogger("goblet.deployer")
 log.setLevel(logging.INFO)
 
 
-def check_or_enable_service(resources: list[str], enable: bool = False):
+def check_or_enable_service(resources, enable=False):
     client = VersionedClients().service_usage
     if enable:
         resp = client.execute(
@@ -43,7 +43,7 @@ def check_or_enable_service(resources: list[str], enable: bool = False):
         for resource in resources:
             log.info(f"{resource} enabled")
     else:
-        resp = client.service_usage.execute(
+        resp = client.execute(
             "batchGet",
             parent_key="parent",
             parent_schema="projects/{project_id}",

--- a/goblet/common_cloud_actions.py
+++ b/goblet/common_cloud_actions.py
@@ -24,9 +24,9 @@ log.setLevel(logging.INFO)
 
 
 def check_or_enable_service(resources: list[str], enable: bool = False):
-    versioned_clients = VersionedClients()
+    client = VersionedClients().service_usage
     if enable:
-        resp = versioned_clients.service_usage.execute(
+        resp = client.execute(
             "batchEnable",
             parent_key="parent",
             parent_schema="projects/{project_id}",
@@ -39,13 +39,11 @@ def check_or_enable_service(resources: list[str], enable: bool = False):
             },
         )
         if not resp.get("done"):
-            versioned_clients.service_usage.wait_for_operation(
-                resp["name"], calls="operations"
-            )
+            client.wait_for_operation(resp["name"], calls="operations")
         for resource in resources:
             log.info(f"{resource} enabled")
     else:
-        resp = versioned_clients.service_usage.execute(
+        resp = client.service_usage.execute(
             "batchGet",
             parent_key="parent",
             parent_schema="projects/{project_id}",

--- a/goblet/handlers/bq_remote_function.py
+++ b/goblet/handlers/bq_remote_function.py
@@ -35,6 +35,7 @@ class BigQueryRemoteFunction(Handler):
     valid_backends = ["cloudfunction", "cloudfunctionv2", "cloudrun"]
     can_sync = False
     resource_type = "bqremotefunction"
+    required_apis = ["bigquery", "bigqueryconnection"]
 
     def register(self, name, func, kwargs):
         """

--- a/goblet/handlers/eventarc.py
+++ b/goblet/handlers/eventarc.py
@@ -24,6 +24,7 @@ class EventArc(Handler):
     # Partial implementation can be found here: https://github.com/samdevo/goblet/blob/eventarc-changes/goblet/resources/eventarc.py
     valid_backends = ["cloudrun"]
     can_sync = True
+    required_apis = ["eventarc"]
 
     def __init__(self, name, backend, versioned_clients=None, resources=None):
         super(EventArc, self).__init__(

--- a/goblet/handlers/handler.py
+++ b/goblet/handlers/handler.py
@@ -2,6 +2,7 @@ import logging
 
 from goblet.client import VersionedClients
 from goblet_gcp_client.client import get_default_project, get_default_location
+from goblet.common_cloud_actions import check_or_enable_service
 
 log = logging.getLogger("goblet.deployer")
 log.setLevel(logging.INFO)
@@ -14,6 +15,7 @@ class Handler:
     resources = None
     resource_type = ""
     can_sync = False
+    required_apis = []
 
     def __init__(
         self,
@@ -62,3 +64,8 @@ class Handler:
         if other.resources:
             self.resources.update(other.resources)
         return self
+
+    def check_or_enable_service(self, enable=False):
+        if not self.resources:
+            return
+        return check_or_enable_service(self.client.resource, enable)

--- a/goblet/handlers/handler.py
+++ b/goblet/handlers/handler.py
@@ -65,7 +65,7 @@ class Handler:
             self.resources.update(other.resources)
         return self
 
-    def check_or_enable_service(self, enable=False):
+    def _check_or_enable_service(self, enable=False):
         if not self.resources:
             return
-        return check_or_enable_service(self.client.resource, enable)
+        return check_or_enable_service(self.required_apis, enable)

--- a/goblet/handlers/jobs.py
+++ b/goblet/handlers/jobs.py
@@ -18,6 +18,7 @@ class Jobs(Handler):
     resource_type = "job"
     valid_backends = ["cloudrun"]
     can_sync = True
+    required_apis = ["cloudbuild", "run"]
 
     def register(self, name, func, kwargs):
         task_id = kwargs["task_id"]

--- a/goblet/handlers/pubsub.py
+++ b/goblet/handlers/pubsub.py
@@ -27,7 +27,7 @@ class PubSub(Handler):
     valid_backends = ["cloudfunction", "cloudfunctionv2", "cloudrun"]
     resource_type = "pubsub"
     can_sync = True
-    required_apis = ["pubsub", "cloudfunctions", "apigateway"]
+    required_apis = ["pubsub", "cloudfunctions"]
 
     def register(self, name, func, kwargs):
         topic = kwargs["topic"]

--- a/goblet/handlers/pubsub.py
+++ b/goblet/handlers/pubsub.py
@@ -27,6 +27,7 @@ class PubSub(Handler):
     valid_backends = ["cloudfunction", "cloudfunctionv2", "cloudrun"]
     resource_type = "pubsub"
     can_sync = True
+    required_apis = ["pubsub", "cloudfunctions", "apigateway"]
 
     def register(self, name, func, kwargs):
         topic = kwargs["topic"]

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -26,7 +26,7 @@ class Routes(Handler):
 
     resource_type = "routes"
     valid_backends = ["cloudfunction", "cloudrun", "cloudfunctionv2"]
-    required_apis = ["cloudfunctions"]
+    required_apis = ["cloudfunctions", "apigateway"]
 
     def __init__(
         self,

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -26,6 +26,7 @@ class Routes(Handler):
 
     resource_type = "routes"
     valid_backends = ["cloudfunction", "cloudrun", "cloudfunctionv2"]
+    required_apis = ["cloudfunctions"]
 
     def __init__(
         self,

--- a/goblet/handlers/scheduler.py
+++ b/goblet/handlers/scheduler.py
@@ -20,6 +20,7 @@ class Scheduler(Handler):
     resource_type = "scheduler"
     valid_backends = ["cloudfunction", "cloudfunctionv2", "cloudrun"]
     can_sync = True
+    required_apis = ["cloudscheduler"]
 
     def register(self, name, func, kwargs):
         schedule = kwargs["schedule"]

--- a/goblet/handlers/storage.py
+++ b/goblet/handlers/storage.py
@@ -26,6 +26,7 @@ class Storage(Handler):
 
     resource_type = "storage"
     valid_backends = ["cloudfunction", "cloudfunctionv2"]
+    required_apis = ["cloudfunctions"]
 
     def __init__(self, name, backend, versioned_clients=None, resources=None):
         super(Storage, self).__init__(

--- a/goblet/infrastructures/alerts.py
+++ b/goblet/infrastructures/alerts.py
@@ -20,6 +20,7 @@ class Alerts(Infrastructure):
     resource_type = "alerts"
     can_sync = True
     _gcp_deployed_alerts = {}
+    required_apis = ["logging"]
 
     def register(self, name, **kwargs):
         kwargs = kwargs.get("kwargs", {})

--- a/goblet/infrastructures/apigateway.py
+++ b/goblet/infrastructures/apigateway.py
@@ -14,6 +14,7 @@ class ApiGateway(Infrastructure):
     """Api Gateway that is deployed with an existing openapi spec"""
 
     resource_type = "apigateway"
+    required_apis = ["apigateway"]
 
     def register(self, name, **kwargs):
         kwargs = kwargs["kwargs"]

--- a/goblet/infrastructures/cloudtask.py
+++ b/goblet/infrastructures/cloudtask.py
@@ -77,6 +77,7 @@ class CloudTaskClient:
 
 class CloudTaskQueue(Infrastructure):
     resource_type = "cloudtaskqueue"
+    required_apis = ["cloudtasks"]
 
     # https://cloud.google.com/apis/design/resource_names
     def register(self, name, kwargs):

--- a/goblet/infrastructures/infrastructure.py
+++ b/goblet/infrastructures/infrastructure.py
@@ -43,7 +43,7 @@ class Infrastructure:
     def get_config(self, config={}):
         return None
 
-    def check_or_enable_service(self, enable=False):
+    def _check_or_enable_service(self, enable=False):
         if not self.resource:
             return
         return check_or_enable_service(self.required_apis, enable)

--- a/goblet/infrastructures/infrastructure.py
+++ b/goblet/infrastructures/infrastructure.py
@@ -1,5 +1,6 @@
 from goblet.client import VersionedClients
 from goblet.config import GConfig
+from goblet.common_cloud_actions import check_or_enable_service
 
 
 class Infrastructure:
@@ -7,6 +8,7 @@ class Infrastructure:
 
     resource_type = ""
     can_sync = False
+    required_apis = []
 
     def __init__(
         self,
@@ -40,3 +42,8 @@ class Infrastructure:
 
     def get_config(self, config={}):
         return None
+
+    def check_or_enable_service(self, enable=False):
+        if not self.resource:
+            return
+        return check_or_enable_service(self.required_apis, enable)

--- a/goblet/infrastructures/redis.py
+++ b/goblet/infrastructures/redis.py
@@ -9,6 +9,7 @@ log.setLevel(logging.INFO)
 class Redis(Infrastructure):
     resource_type = "redis"
     update_keys = ["displayName", "labels", "memorySizeGb", "replicaCount"]
+    required_apis = ["redis"]
 
     def register(self, name, kwargs):
         self.resource = {"name": name}

--- a/goblet/infrastructures/vpcconnector.py
+++ b/goblet/infrastructures/vpcconnector.py
@@ -9,6 +9,7 @@ log.setLevel(logging.INFO)
 
 class VPCConnector(Infrastructure):
     resource_type = "vpcconnector"
+    required_apis = ["vpcaccess"]
 
     def register(self, name, kwargs):
         self.resource = {"name": name}

--- a/goblet/tests/data/http/services-check/get-v1-projects-goblet-services-batchGet_1.json
+++ b/goblet/tests/data/http/services-check/get-v1-projects-goblet-services-batchGet_1.json
@@ -1,0 +1,2702 @@
+{
+  "headers": {},
+  "body": {
+    "services": [
+      {
+        "name": "projects/goblet/services/cloudfunctions.googleapis.com",
+        "config": {
+          "name": "cloudfunctions.googleapis.com",
+          "title": "Cloud Functions API",
+          "apis": [
+            {
+              "name": "google.longrunning.Operations",
+              "methods": [
+                {
+                  "name": "ListOperations"
+                },
+                {
+                  "name": "GetOperation"
+                },
+                {
+                  "name": "DeleteOperation"
+                },
+                {
+                  "name": "CancelOperation"
+                },
+                {
+                  "name": "WaitOperation"
+                }
+              ],
+              "version": "v1"
+            },
+            {
+              "name": "google.cloud.functions.v2alpha.FunctionService",
+              "methods": [
+                {
+                  "name": "GetFunction"
+                },
+                {
+                  "name": "ListFunctions"
+                },
+                {
+                  "name": "CreateFunction"
+                },
+                {
+                  "name": "UpdateFunction"
+                },
+                {
+                  "name": "SetupFunctionUpgradeConfig"
+                },
+                {
+                  "name": "AbortFunctionUpgrade"
+                },
+                {
+                  "name": "RedirectFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "RollbackFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "CommitFunctionUpgrade"
+                },
+                {
+                  "name": "DeleteFunction"
+                },
+                {
+                  "name": "GenerateUploadUrl"
+                },
+                {
+                  "name": "GenerateDownloadUrl"
+                },
+                {
+                  "name": "ListRuntimes"
+                }
+              ],
+              "version": "v2alpha"
+            },
+            {
+              "name": "google.iam.v1.IAMPolicy",
+              "methods": [
+                {
+                  "name": "SetIamPolicy"
+                },
+                {
+                  "name": "GetIamPolicy"
+                },
+                {
+                  "name": "TestIamPermissions"
+                }
+              ],
+              "version": "v1"
+            },
+            {
+              "name": "google.cloud.functions.v2beta.FunctionService",
+              "methods": [
+                {
+                  "name": "GetFunction"
+                },
+                {
+                  "name": "ListFunctions"
+                },
+                {
+                  "name": "CreateFunction"
+                },
+                {
+                  "name": "UpdateFunction"
+                },
+                {
+                  "name": "SetupFunctionUpgradeConfig"
+                },
+                {
+                  "name": "AbortFunctionUpgrade"
+                },
+                {
+                  "name": "RedirectFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "RollbackFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "CommitFunctionUpgrade"
+                },
+                {
+                  "name": "DeleteFunction"
+                },
+                {
+                  "name": "GenerateUploadUrl"
+                },
+                {
+                  "name": "GenerateDownloadUrl"
+                },
+                {
+                  "name": "ListRuntimes"
+                }
+              ],
+              "version": "v2beta"
+            },
+            {
+              "name": "google.cloud.functions.v2.FunctionService",
+              "methods": [
+                {
+                  "name": "GetFunction"
+                },
+                {
+                  "name": "ListFunctions"
+                },
+                {
+                  "name": "CreateFunction"
+                },
+                {
+                  "name": "UpdateFunction"
+                },
+                {
+                  "name": "SetupFunctionUpgradeConfig"
+                },
+                {
+                  "name": "AbortFunctionUpgrade"
+                },
+                {
+                  "name": "RedirectFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "RollbackFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "CommitFunctionUpgrade"
+                },
+                {
+                  "name": "DeleteFunction"
+                },
+                {
+                  "name": "GenerateUploadUrl"
+                },
+                {
+                  "name": "GenerateDownloadUrl"
+                },
+                {
+                  "name": "ListRuntimes"
+                }
+              ],
+              "version": "v2"
+            },
+            {
+              "name": "google.cloud.functions.v2main.FunctionService",
+              "methods": [
+                {
+                  "name": "GetFunction"
+                },
+                {
+                  "name": "ListFunctions"
+                },
+                {
+                  "name": "CreateFunction"
+                },
+                {
+                  "name": "UpdateFunction"
+                },
+                {
+                  "name": "SetupFunctionUpgradeConfig"
+                },
+                {
+                  "name": "AbortFunctionUpgrade"
+                },
+                {
+                  "name": "RedirectFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "RollbackFunctionUpgradeTraffic"
+                },
+                {
+                  "name": "CommitFunctionUpgrade"
+                },
+                {
+                  "name": "DeleteFunction"
+                },
+                {
+                  "name": "GenerateUploadUrl"
+                },
+                {
+                  "name": "GenerateDownloadUrl"
+                },
+                {
+                  "name": "ListRuntimes"
+                }
+              ],
+              "version": "v2main"
+            },
+            {
+              "name": "google.cloud.functions.v1.CloudFunctionsService",
+              "methods": [
+                {
+                  "name": "ListFunctions"
+                },
+                {
+                  "name": "GetFunction"
+                },
+                {
+                  "name": "CreateFunction"
+                },
+                {
+                  "name": "UpdateFunction"
+                },
+                {
+                  "name": "DeleteFunction"
+                },
+                {
+                  "name": "CallFunction"
+                },
+                {
+                  "name": "GenerateUploadUrl"
+                },
+                {
+                  "name": "GenerateDownloadUrl"
+                },
+                {
+                  "name": "SetIamPolicy"
+                },
+                {
+                  "name": "GetIamPolicy"
+                },
+                {
+                  "name": "TestIamPermissions"
+                }
+              ],
+              "version": "v1"
+            },
+            {
+              "name": "google.cloud.location.Locations",
+              "methods": [
+                {
+                  "name": "ListLocations"
+                },
+                {
+                  "name": "GetLocation"
+                }
+              ],
+              "version": "v1"
+            },
+            {
+              "name": "google.discovery.Discovery",
+              "methods": [
+                {
+                  "name": "GetDiscovery"
+                },
+                {
+                  "name": "GetDiscoveryRest"
+                }
+              ],
+              "version": "v1"
+            }
+          ],
+          "documentation": {
+            "summary": "Manages lightweight user-provided functions executed in response to events."
+          },
+          "quota": {
+            "limits": [
+              {
+                "name": "ReadRequestsPerMinutePerProject",
+                "metric": "cloudfunctions.googleapis.com/read_requests",
+                "unit": "1/min/{project}",
+                "values": {
+                  "STANDARD": "300",
+                  "STANDARD/{billable=true}": "3000"
+                }
+              },
+              {
+                "name": "WriteRequestsPerMinutePerProject",
+                "metric": "cloudfunctions.googleapis.com/write_requests",
+                "unit": "1/min/{project}",
+                "values": {
+                  "STANDARD": "15",
+                  "STANDARD/{billable=true}": "50"
+                }
+              },
+              {
+                "name": "TestCallRequestsPerMinutePerProject",
+                "metric": "cloudfunctions.googleapis.com/test_call_requests",
+                "unit": "1/min/{project}",
+                "values": {
+                  "STANDARD": "5",
+                  "STANDARD/{billable=true}": "10"
+                }
+              },
+              {
+                "name": "BuildTimePerDayPerProject",
+                "metric": "cloudfunctions.googleapis.com/build_time",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "12000",
+                  "STANDARD/{billable=true}": "300000"
+                }
+              },
+              {
+                "name": "V2WriteRequestsPerMinutePerProjectPerRegion",
+                "metric": "cloudfunctions.googleapis.com/v2_write_requests_regional",
+                "unit": "1/min/{project}/{region}",
+                "values": {
+                  "STANDARD": "60",
+                  "STANDARD/{billable=true}": "60"
+                }
+              },
+              {
+                "name": "V2ReadRequestsPerMinutePerProjectPerRegion",
+                "metric": "cloudfunctions.googleapis.com/v2_read_requests_regional",
+                "unit": "1/min/{project}/{region}",
+                "values": {
+                  "STANDARD": "1200",
+                  "STANDARD/{billable=true}": "1200"
+                }
+              },
+              {
+                "description": "API requests for listing and reading entities (deprecated)",
+                "maxLimit": "5000",
+                "name": "USER-100s",
+                "metric": "Read",
+                "unit": "1/100s/{project}/{user}",
+                "values": {
+                  "STANDARD": "5000"
+                }
+              },
+              {
+                "description": "API requests for listing and reading entities",
+                "maxLimit": "5000",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "Read",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "5000"
+                }
+              },
+              {
+                "description": "API requests for creating, modifying or deleting functions (deprecated)",
+                "maxLimit": "80",
+                "name": "USER-100s",
+                "metric": "Write",
+                "unit": "1/100s/{project}/{user}",
+                "values": {
+                  "STANDARD": "80"
+                }
+              },
+              {
+                "description": "API requests for creating, modifying or deleting functions",
+                "maxLimit": "80",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "Write",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "80"
+                }
+              },
+              {
+                "description": "API requests for performing a test function invocation (deprecated)",
+                "maxLimit": "16",
+                "name": "USER-100s",
+                "metric": "TestCall",
+                "unit": "1/100s/{project}/{user}",
+                "values": {
+                  "STANDARD": "16"
+                }
+              },
+              {
+                "description": "API requests for performing a test function invocation",
+                "maxLimit": "16",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "TestCall",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "16"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "CPUMilliSecondsDaily",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to resolve a domain name (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "DNSResolutions",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "72000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "BuildTime",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "72000"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-us-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-us-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-us-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-us-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-us-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-us-east4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-us-east4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-us-east4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-us-east4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-us-east4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-us-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-us-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-us-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-us-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-us-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-us-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-us-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-us-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-us-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-us-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-us-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-us-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-us-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-us-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-us-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-europe-west1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-europe-west1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-europe-west1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-europe-west1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-europe-west1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-europe-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-europe-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-europe-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-europe-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-europe-west2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-europe-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-europe-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-europe-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-europe-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-europe-west3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-europe-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-europe-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-europe-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-europe-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-europe-west4",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-europe-west6",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-europe-west6",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-europe-west6",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-europe-west6",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-europe-west6",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-east2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-east2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-east2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-east2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-east2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-northeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-northeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-northeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-northeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-northeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-south1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-northeast3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-northeast3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-northeast3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-northeast3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-northeast3",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-south1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-south1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-south1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-south1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-northamerica-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-northamerica-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-northamerica-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-northamerica-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-northamerica-northeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-southamerica-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-southamerica-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-southamerica-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-southamerica-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-southamerica-east1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-australia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-australia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-australia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-australia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-australia-southeast1",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "Memory allocation for the quota is measured in MB-milliseconds\n",
+                "maxLimit": "-1",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "MiByMilliSeconds",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "-1"
+                }
+              },
+              {
+                "maxLimit": "-1",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "HttpRequestData",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "-1"
+                }
+              },
+              {
+                "maxLimit": "-1",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "HttpResponseData",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "-1"
+                }
+              },
+              {
+                "description": "API requests for listing and reading entities",
+                "maxLimit": "10000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "ReadNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "10000"
+                }
+              },
+              {
+                "description": "API requests for listing and reading entities (deprecated)",
+                "maxLimit": "500",
+                "name": "USER-100s",
+                "metric": "ReadNonbillable",
+                "unit": "1/100s/{project}/{user}",
+                "values": {
+                  "STANDARD": "500"
+                }
+              },
+              {
+                "description": "API requests for listing and reading entities",
+                "maxLimit": "500",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "ReadNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "500"
+                }
+              },
+              {
+                "description": "API requests for creating, modifying or deleting functions",
+                "maxLimit": "1000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "WriteNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1000"
+                }
+              },
+              {
+                "description": "API requests for creating, modifying or deleting functions (deprecated)",
+                "maxLimit": "20",
+                "name": "USER-100s",
+                "metric": "WriteNonbillable",
+                "unit": "1/100s/{project}/{user}",
+                "values": {
+                  "STANDARD": "20"
+                }
+              },
+              {
+                "description": "API requests for creating, modifying or deleting functions",
+                "maxLimit": "20",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "WriteNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "20"
+                }
+              },
+              {
+                "description": "API requests for performing a test function invocation",
+                "maxLimit": "1000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "TestCallNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1000"
+                }
+              },
+              {
+                "description": "API requests for performing a test function invocation (deprecated)",
+                "maxLimit": "10",
+                "name": "USER-100s",
+                "metric": "TestCallNonbillable",
+                "unit": "1/100s/{project}/{user}",
+                "values": {
+                  "STANDARD": "10"
+                }
+              },
+              {
+                "description": "API requests for performing a test function invocation",
+                "maxLimit": "10",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "TestCallNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "10"
+                }
+              },
+              {
+                "maxLimit": "5000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "FunctionCallsNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "5000"
+                }
+              },
+              {
+                "maxLimit": "50",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCallsNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "50"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds",
+                "maxLimit": "1500000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "CPUMilliSecondsNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1500000"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds",
+                "maxLimit": "100000",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSecondsNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "100000"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds",
+                "maxLimit": "1500000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "CPUMilliSecondsDailyNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1500000"
+                }
+              },
+              {
+                "maxLimit": "1073741824",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "NetworkIngressNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1073741824"
+                }
+              },
+              {
+                "maxLimit": "20971520",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngressNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "20971520"
+                }
+              },
+              {
+                "maxLimit": "1073741824",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "NetworkEgressNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1073741824"
+                }
+              },
+              {
+                "maxLimit": "20971520",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgressNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "20971520"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection",
+                "maxLimit": "5000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "SocketConnectNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "5000"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection",
+                "maxLimit": "50",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnectNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "50"
+                }
+              },
+              {
+                "description": "The number of attempts to resolve a domain name",
+                "maxLimit": "5000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "DNSResolutionsNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "5000"
+                }
+              },
+              {
+                "description": "The number of attempts to resolve a domain name",
+                "maxLimit": "50",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "DNSResolutionsNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "50"
+                }
+              },
+              {
+                "maxLimit": "12000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "BuildTimeNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "12000"
+                }
+              },
+              {
+                "description": "Memory allocation for the quota is measured in MB-milliseconds\n",
+                "maxLimit": "1536000000",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "MiByMilliSecondsNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1536000000"
+                }
+              },
+              {
+                "description": "Memory allocation for the quota is measured in MB-milliseconds\n",
+                "maxLimit": "102400000",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "MiByMilliSecondsNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "102400000"
+                }
+              },
+              {
+                "maxLimit": "1073741824",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "HttpRequestDataNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1073741824"
+                }
+              },
+              {
+                "maxLimit": "20971520",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "HttpRequestDataNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "20971520"
+                }
+              },
+              {
+                "maxLimit": "1073741824",
+                "name": "CLIENT_PROJECT-1d",
+                "metric": "HttpResponseDataNonbillable",
+                "unit": "1/d/{project}",
+                "values": {
+                  "STANDARD": "1073741824"
+                }
+              },
+              {
+                "maxLimit": "20971520",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "HttpResponseDataNonbillable",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "20971520"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "FunctionCalls-asia-southeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "CPU allocation for the quota is measured in MHz-seconds (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "CPUMilliSeconds-asia-southeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkIngress-asia-southeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "NetworkEgress-asia-southeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              },
+              {
+                "description": "The number of attempts to establish a TCP connection (deprecated)",
+                "maxLimit": "9223372036854775807",
+                "name": "CLIENT_PROJECT-100s",
+                "metric": "SocketConnect-asia-southeast2",
+                "unit": "1/100s/{project}",
+                "values": {
+                  "STANDARD": "9223372036854775807"
+                }
+              }
+            ]
+          },
+          "authentication": {
+            "rules": [
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform,"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloudfunctions,\nhttps://www.googleapis.com/auth/cloud-platform"
+                }
+              }
+            ]
+          },
+          "usage": {
+            "requirements": [
+              "serviceusage.googleapis.com/tos/cloud"
+            ]
+          },
+          "endpoints": [
+            {
+              "name": "cloudfunctions.googleapis.com"
+            },
+            {
+              "name": "cloudfunctions.clients6.google.com"
+            },
+            {
+              "name": "content-cloudfunctions.googleapis.com"
+            },
+            {
+              "name": "cloudfunctions.mtls.googleapis.com"
+            },
+            {
+              "name": "cloudfunctions.mtls.clients6.google.com"
+            },
+            {
+              "name": "content-cloudfunctions.mtls.googleapis.com"
+            }
+          ],
+          "monitoredResources": [
+            {
+              "type": "cloudfunctions.googleapis.com/function",
+              "labels": [
+                {
+                  "key": "cloud.googleapis.com/location"
+                },
+                {
+                  "key": "cloud.googleapis.com/uid"
+                },
+                {
+                  "key": "cloud.googleapis.com/project"
+                },
+                {
+                  "key": "cloudfunctions.googleapis.com/function_name"
+                }
+              ]
+            },
+            {
+              "type": "serviceruntime.googleapis.com/api",
+              "labels": [
+                {
+                  "key": "cloud.googleapis.com/location"
+                },
+                {
+                  "key": "cloud.googleapis.com/uid"
+                },
+                {
+                  "key": "serviceruntime.googleapis.com/api_version"
+                },
+                {
+                  "key": "serviceruntime.googleapis.com/api_method"
+                },
+                {
+                  "key": "serviceruntime.googleapis.com/consumer_project"
+                },
+                {
+                  "key": "cloud.googleapis.com/project"
+                },
+                {
+                  "key": "cloud.googleapis.com/service"
+                }
+              ]
+            },
+            {
+              "type": "serviceruntime.googleapis.com/consumer_quota",
+              "labels": [
+                {
+                  "key": "cloud.googleapis.com/location"
+                },
+                {
+                  "key": "cloud.googleapis.com/uid"
+                },
+                {
+                  "key": "cloud.googleapis.com/service"
+                },
+                {
+                  "key": "cloud.googleapis.com/resource_id"
+                },
+                {
+                  "key": "cloud.googleapis.com/resource_node"
+                },
+                {
+                  "key": "cloud.googleapis.com/quota_metric"
+                },
+                {
+                  "key": "cloud.googleapis.com/quota_location"
+                }
+              ]
+            },
+            {
+              "type": "serviceruntime.googleapis.com/producer_quota",
+              "labels": [
+                {
+                  "key": "cloud.googleapis.com/location"
+                },
+                {
+                  "key": "cloud.googleapis.com/uid"
+                },
+                {
+                  "key": "cloud.googleapis.com/service"
+                },
+                {
+                  "key": "cloud.googleapis.com/resource_id"
+                },
+                {
+                  "key": "cloud.googleapis.com/resource_node"
+                },
+                {
+                  "key": "cloud.googleapis.com/consumer_resource_node"
+                },
+                {
+                  "key": "cloud.googleapis.com/quota_metric"
+                },
+                {
+                  "key": "cloud.googleapis.com/quota_location"
+                }
+              ]
+            }
+          ],
+          "monitoring": {
+            "consumerDestinations": [
+              {
+                "monitoredResource": "cloudfunctions.googleapis.com/function",
+                "metrics": [
+                  "cloudfunctions.googleapis.com/function/execution_times",
+                  "cloudfunctions.googleapis.com/function/execution_count",
+                  "cloudfunctions.googleapis.com/function/user_memory_bytes",
+                  "cloudfunctions.googleapis.com/function/network_egress",
+                  "cloudfunctions.googleapis.com/function/active_instances",
+                  "cloudfunctions.googleapis.com/function/execution_delays",
+                  "cloudfunctions.googleapis.com/function/execution_count_internal",
+                  "cloudfunctions.googleapis.com/function/supervisor_gcu_times",
+                  "cloudfunctions.googleapis.com/function/supervisor_memory_bytes",
+                  "cloudfunctions.googleapis.com/function/user_gcu_times",
+                  "cloudfunctions.googleapis.com/function/supervisor_chemist_rpc_error_count",
+                  "cloudfunctions.googleapis.com/function/supervisor_controlled_death_count",
+                  "cloudfunctions.googleapis.com/function/supervisor_report_count",
+                  "cloudfunctions.googleapis.com/function/supervisor_report_latencies",
+                  "cloudfunctions.googleapis.com/function/supervisor_phase_latencies"
+                ]
+              },
+              {
+                "monitoredResource": "serviceruntime.googleapis.com/api",
+                "metrics": [
+                  "serviceruntime.googleapis.com/api/consumer/request_count",
+                  "serviceruntime.googleapis.com/api/consumer/error_count",
+                  "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+                  "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+                  "serviceruntime.googleapis.com/api/consumer/total_latencies",
+                  "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+                  "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+                  "serviceruntime.googleapis.com/api/consumer/request_sizes",
+                  "serviceruntime.googleapis.com/api/consumer/response_sizes",
+                  "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+                  "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+                  "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+                  "serviceruntime.googleapis.com/quota/used",
+                  "serviceruntime.googleapis.com/quota/limit",
+                  "serviceruntime.googleapis.com/quota/exceeded",
+                  "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+                ]
+              },
+              {
+                "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+                "metrics": [
+                  "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+                  "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+                  "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+                  "serviceruntime.googleapis.com/quota/consumer/limit",
+                  "serviceruntime.googleapis.com/quota/consumer/exceeded"
+                ]
+              }
+            ]
+          }
+        },
+        "state": "ENABLED",
+        "parent": "projects/1234567890"
+      },
+      {
+        "name": "projects/goblet/services/secretmanager.googleapis.com",
+        "config": {
+          "name": "secretmanager.googleapis.com",
+          "title": "Secret Manager API",
+          "apis": [
+            {
+              "name": "google.cloud.location.Locations",
+              "methods": [
+                {
+                  "name": "ListLocations"
+                },
+                {
+                  "name": "GetLocation"
+                }
+              ],
+              "version": "v1"
+            },
+            {
+              "name": "google.cloud.secretmanager.v1.SecretManagerService",
+              "methods": [
+                {
+                  "name": "ListSecrets"
+                },
+                {
+                  "name": "CreateSecret"
+                },
+                {
+                  "name": "AddSecretVersion"
+                },
+                {
+                  "name": "GetSecret"
+                },
+                {
+                  "name": "UpdateSecret"
+                },
+                {
+                  "name": "DeleteSecret"
+                },
+                {
+                  "name": "ListSecretVersions"
+                },
+                {
+                  "name": "GetSecretVersion"
+                },
+                {
+                  "name": "AccessSecretVersion"
+                },
+                {
+                  "name": "DisableSecretVersion"
+                },
+                {
+                  "name": "EnableSecretVersion"
+                },
+                {
+                  "name": "DestroySecretVersion"
+                },
+                {
+                  "name": "SetIamPolicy"
+                },
+                {
+                  "name": "GetIamPolicy"
+                },
+                {
+                  "name": "TestIamPermissions"
+                }
+              ],
+              "version": "v1"
+            },
+            {
+              "name": "google.cloud.secrets.v1beta1.SecretManagerService",
+              "methods": [
+                {
+                  "name": "ListSecrets"
+                },
+                {
+                  "name": "CreateSecret"
+                },
+                {
+                  "name": "AddSecretVersion"
+                },
+                {
+                  "name": "GetSecret"
+                },
+                {
+                  "name": "UpdateSecret"
+                },
+                {
+                  "name": "DeleteSecret"
+                },
+                {
+                  "name": "ListSecretVersions"
+                },
+                {
+                  "name": "GetSecretVersion"
+                },
+                {
+                  "name": "AccessSecretVersion"
+                },
+                {
+                  "name": "DisableSecretVersion"
+                },
+                {
+                  "name": "EnableSecretVersion"
+                },
+                {
+                  "name": "DestroySecretVersion"
+                },
+                {
+                  "name": "SetIamPolicy"
+                },
+                {
+                  "name": "GetIamPolicy"
+                },
+                {
+                  "name": "TestIamPermissions"
+                }
+              ],
+              "version": "v1beta1"
+            },
+            {
+              "name": "google.discovery.Discovery",
+              "methods": [
+                {
+                  "name": "GetDiscovery"
+                },
+                {
+                  "name": "GetDiscoveryRest"
+                }
+              ],
+              "version": "v1"
+            }
+          ],
+          "documentation": {
+            "summary": "Stores sensitive data such as API keys, passwords, and certificates. Provides convenience while improving security.\n"
+          },
+          "quota": {
+            "limits": [
+              {
+                "name": "ReadRequestsPerMinutePerProject",
+                "metric": "secretmanager.googleapis.com/read_requests",
+                "unit": "1/min/{project}",
+                "values": {
+                  "STANDARD": "600",
+                  "HIGH": "6000",
+                  "VERY_HIGH": "60000"
+                }
+              },
+              {
+                "name": "AccessRequestsPerMinutePerProject",
+                "metric": "secretmanager.googleapis.com/access_requests",
+                "unit": "1/min/{project}",
+                "values": {
+                  "STANDARD": "90000",
+                  "HIGH": "180000",
+                  "VERY_HIGH": "360000"
+                }
+              },
+              {
+                "name": "WriteRequestsPerMinutePerProject",
+                "metric": "secretmanager.googleapis.com/write_requests",
+                "unit": "1/min/{project}",
+                "values": {
+                  "STANDARD": "600",
+                  "HIGH": "1200",
+                  "VERY_HIGH": "2400"
+                }
+              }
+            ]
+          },
+          "authentication": {
+            "rules": [
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              },
+              {
+                "oauth": {
+                  "canonicalScopes": "https://www.googleapis.com/auth/cloud-platform"
+                }
+              }
+            ]
+          },
+          "usage": {
+            "requirements": [
+              "serviceusage.googleapis.com/tos/cloud",
+              "serviceusage.googleapis.com/billing-enabled"
+            ]
+          },
+          "endpoints": [
+            {
+              "name": "secretmanager.googleapis.com"
+            },
+            {
+              "name": "secretmanager.clients6.google.com"
+            },
+            {
+              "name": "content-secretmanager.googleapis.com"
+            },
+            {
+              "name": "secretmanager.mtls.googleapis.com"
+            },
+            {
+              "name": "secretmanager.mtls.clients6.google.com"
+            },
+            {
+              "name": "content-secretmanager.mtls.googleapis.com"
+            }
+          ],
+          "monitoring": {}
+        },
+        "state": "ENABLED",
+        "parent": "projects/1234567890"
+      }
+    ]
+  }
+}

--- a/goblet/tests/data/http/services-enable/get-v1-operations-acat.p2-1234567890-5a312762-427a-499f-8025-ab8150acd344_1.json
+++ b/goblet/tests/data/http/services-enable/get-v1-operations-acat.p2-1234567890-5a312762-427a-499f-8025-ab8150acd344_1.json
@@ -1,0 +1,243 @@
+{
+  "headers": {},
+  "body": {
+    "name": "operations/acat.p2-1234567890-5a312762-427a-499f-8025-ab8150acd344",
+    "metadata": {
+      "@type": "type.googleapis.com/google.protobuf.Empty"
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.api.serviceusage.v1.BatchEnableServicesResponse",
+      "services": [
+        {
+          "name": "projects/goblet/services/cloudfunctions.googleapis.com",
+          "config": {
+            "name": "cloudfunctions.googleapis.com",
+            "title": "Cloud Functions API",
+            "documentation": {
+              "summary": "Manages lightweight user-provided functions executed in response to events."
+            },
+            "quota": {},
+            "authentication": {},
+            "usage": {
+              "requirements": [
+                "serviceusage.googleapis.com/tos/cloud"
+              ]
+            },
+            "monitoredResources": [
+              {
+                "type": "cloudfunctions.googleapis.com/function",
+                "labels": [
+                  {
+                    "key": "cloud.googleapis.com/location"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/uid"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/project"
+                  },
+                  {
+                    "key": "cloudfunctions.googleapis.com/function_name"
+                  }
+                ]
+              },
+              {
+                "type": "cloud_function",
+                "labels": [
+                  {
+                    "key": "cloudfunctions.googleapis.com/function_name"
+                  },
+                  {
+                    "key": "cloudfunctions.googleapis.com/region"
+                  }
+                ]
+              },
+              {
+                "type": "serviceruntime.googleapis.com/api",
+                "labels": [
+                  {
+                    "key": "cloud.googleapis.com/location"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/uid"
+                  },
+                  {
+                    "key": "serviceruntime.googleapis.com/api_version"
+                  },
+                  {
+                    "key": "serviceruntime.googleapis.com/api_method"
+                  },
+                  {
+                    "key": "serviceruntime.googleapis.com/consumer_project"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/project"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/service"
+                  }
+                ]
+              },
+              {
+                "type": "serviceruntime.googleapis.com/consumer_quota",
+                "labels": [
+                  {
+                    "key": "cloud.googleapis.com/location"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/uid"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/service"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/resource_id"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/resource_node"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/quota_metric"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/quota_location"
+                  }
+                ]
+              },
+              {
+                "type": "serviceruntime.googleapis.com/producer_quota",
+                "labels": [
+                  {
+                    "key": "cloud.googleapis.com/location"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/uid"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/service"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/resource_id"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/resource_node"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/consumer_resource_node"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/quota_metric"
+                  },
+                  {
+                    "key": "cloud.googleapis.com/quota_location"
+                  }
+                ]
+              }
+            ],
+            "monitoring": {
+              "consumerDestinations": [
+                {
+                  "monitoredResource": "cloudfunctions.googleapis.com/function",
+                  "metrics": [
+                    "cloudfunctions.googleapis.com/function/execution_times",
+                    "cloudfunctions.googleapis.com/function/execution_count",
+                    "cloudfunctions.googleapis.com/function/user_memory_bytes",
+                    "cloudfunctions.googleapis.com/function/network_egress",
+                    "cloudfunctions.googleapis.com/function/active_instances",
+                    "cloudfunctions.googleapis.com/function/execution_delays",
+                    "cloudfunctions.googleapis.com/function/execution_count_internal",
+                    "cloudfunctions.googleapis.com/function/supervisor_gcu_times",
+                    "cloudfunctions.googleapis.com/function/supervisor_memory_bytes",
+                    "cloudfunctions.googleapis.com/function/user_gcu_times",
+                    "cloudfunctions.googleapis.com/function/supervisor_chemist_rpc_error_count",
+                    "cloudfunctions.googleapis.com/function/supervisor_controlled_death_count",
+                    "cloudfunctions.googleapis.com/function/supervisor_report_count",
+                    "cloudfunctions.googleapis.com/function/supervisor_report_latencies",
+                    "cloudfunctions.googleapis.com/function/supervisor_phase_latencies"
+                  ]
+                },
+                {
+                  "monitoredResource": "serviceruntime.googleapis.com/api",
+                  "metrics": [
+                    "serviceruntime.googleapis.com/api/consumer/request_count",
+                    "serviceruntime.googleapis.com/api/consumer/error_count",
+                    "serviceruntime.googleapis.com/api/consumer/quota_used_count",
+                    "serviceruntime.googleapis.com/api/consumer/quota_refund_count",
+                    "serviceruntime.googleapis.com/api/consumer/total_latencies",
+                    "serviceruntime.googleapis.com/api/consumer/request_overhead_latencies",
+                    "serviceruntime.googleapis.com/api/consumer/backend_latencies",
+                    "serviceruntime.googleapis.com/api/consumer/request_sizes",
+                    "serviceruntime.googleapis.com/api/consumer/response_sizes",
+                    "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user",
+                    "serviceruntime.googleapis.com/api/consumer/top_request_count_by_end_user_country",
+                    "serviceruntime.googleapis.com/api/consumer/top_request_count_by_referer",
+                    "serviceruntime.googleapis.com/quota/used",
+                    "serviceruntime.googleapis.com/quota/limit",
+                    "serviceruntime.googleapis.com/quota/exceeded",
+                    "serviceruntime.googleapis.com/allocation/consumer/quota_used_count"
+                  ]
+                },
+                {
+                  "monitoredResource": "serviceruntime.googleapis.com/consumer_quota",
+                  "metrics": [
+                    "serviceruntime.googleapis.com/quota/rate/consumer/used_count",
+                    "serviceruntime.googleapis.com/quota/rate/consumer/refund_count",
+                    "serviceruntime.googleapis.com/quota/allocation/consumer/usage",
+                    "serviceruntime.googleapis.com/quota/consumer/limit",
+                    "serviceruntime.googleapis.com/quota/consumer/exceeded"
+                  ]
+                }
+              ]
+            }
+          },
+          "state": "ENABLED",
+          "parent": "projects/1234567890"
+        },
+        {
+          "name": "projects/goblet/services/secretmanager.googleapis.com",
+          "config": {
+            "name": "secretmanager.googleapis.com",
+            "title": "Secret Manager API",
+            "documentation": {
+              "summary": "Stores sensitive data such as API keys, passwords, and certificates. Provides convenience while improving security.\n"
+            },
+            "quota": {},
+            "authentication": {},
+            "usage": {
+              "requirements": [
+                "serviceusage.googleapis.com/tos/cloud",
+                "serviceusage.googleapis.com/billing-enabled"
+              ]
+            },
+            "monitoredResources": [
+              {
+                "type": "secretmanager.googleapis.com/Secret",
+                "displayName": "Secret Manager Secret",
+                "description": "A logical secret whose value and versions can be accessed.",
+                "labels": [
+                  {
+                    "key": "resource_container",
+                    "description": "The identifier of the GCP project associated with this resource."
+                  },
+                  {
+                    "key": "location",
+                    "description": "Location of secret metadata. Always global."
+                  },
+                  {
+                    "key": "secret_id",
+                    "description": "The name given to this secret."
+                  }
+                ],
+                "launchStage": "BETA"
+              }
+            ],
+            "monitoring": {}
+          },
+          "state": "ENABLED",
+          "parent": "projects/1234567890"
+        }
+      ]
+    }
+  }
+}

--- a/goblet/tests/data/http/services-enable/post-v1-projects-goblet-services-batchEnable_1.json
+++ b/goblet/tests/data/http/services-enable/post-v1-projects-goblet-services-batchEnable_1.json
@@ -1,0 +1,13 @@
+{
+  "headers": {},
+  "body": {
+    "name": "operations/acat.p2-1234567890-5a312762-427a-499f-8025-ab8150acd344",
+    "metadata": {
+      "@type": "type.googleapis.com/google.api.serviceusage.v1.OperationMetadata",
+      "resourceNames": [
+        "services/cloudfunctions.googleapis.com/projectSettings/1234567890",
+        "services/secretmanager.googleapis.com/projectSettings/1234567890"
+      ]
+    }
+  }
+}

--- a/goblet/tests/test_services.py
+++ b/goblet/tests/test_services.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock
+from goblet import Goblet
+from goblet_gcp_client import get_responses, get_response
+
+
+class TestServices:
+    def test_check_service_apis_status(self, monkeypatch):
+        app = Goblet(function_name="test-goblet-services")
+        monkeypatch.setenv("G_TEST_NAME", "services-check")
+        monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
+        app.services(enable=False)
+
+        resp = get_response(
+            "services-check",
+            "get-v1-projects-goblet-services-batchGet_1.json",
+        )
+
+        services = resp["body"]["services"]
+        assert "cloudfunctions" in services[0]["name"]
+        assert "secretmanager" in services[1]["name"]
+
+    def test_enable_service_apis(self, monkeypatch):
+        app = Goblet(function_name="test-goblet-services")
+        monkeypatch.setenv("G_TEST_NAME", "services-enable")
+        monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
+        app.services(enable=True)
+
+        resp = get_response(
+            "services-enable",
+            "post-v1-projects-goblet-services-batchEnable_1.json",
+        )
+
+        resources = resp["body"]["metadata"]["resourceNames"]
+        assert "cloudfunctions" in resources[0]
+        assert "secretmanager" in resources[1]

--- a/goblet/tests/test_services.py
+++ b/goblet/tests/test_services.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock
+from goblet_gcp_client import get_response
+
 from goblet import Goblet
-from goblet_gcp_client import get_responses, get_response
 
 
 class TestServices:

--- a/goblet/tests/test_services.py
+++ b/goblet/tests/test_services.py
@@ -10,7 +10,7 @@ class TestServices:
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
         monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
         monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
-        app.services(enable=False)
+        app.check_or_enable_services()
 
         resp = get_response(
             "services-check",
@@ -27,7 +27,7 @@ class TestServices:
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
         monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
         monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
-        app.services(enable=True)
+        app.check_or_enable_services(enable=True)
 
         resp = get_response(
             "services-enable",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DESCRIPTION = "Google Cloud functions wrapper"
 URL = "https://github.com/goblet/goblet"
 EMAIL = "austen.novis@gmail.com"
 AUTHOR = "Austen"
-REQUIRES_PYTHON = ">=3.7.0"
+REQUIRES_PYTHON = ">=3.8.0"
 VERSION = os.environ.get("VERSION")
 
 # What packages are required for this module to be executed?
@@ -116,7 +116,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
- add cli command for checking and enabling gcp service apis
- closes #218 
- limit flake8 and testing to python versions >= 3.8