### PR TITLE
[CLI] Package command correctly closes zipfile

### DIFF
--- a/goblet/cli.py
+++ b/goblet/cli.py
@@ -270,6 +270,7 @@ def package(stage):
             os.environ["STAGE"] = stage
         app = get_goblet_app(GConfig().main_file or "main.py")
         app.package()
+        app.backend.zipf.close()
 
     except FileNotFoundError as not_found:
         click.echo(


### PR DESCRIPTION
* The zipfile was not closed in all cases resulting in a corrupted file during `goblet package`. The zipfile is always closed during `goblet deploy` (closes #357 )