### PR TITLE
update goblet gcp client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     needs: Lint
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     name: Test Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     needs: Lint
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Test Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     needs: Lint
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     name: Test Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2

--- a/goblet/tests/test_vpcconnector.py
+++ b/goblet/tests/test_vpcconnector.py
@@ -3,10 +3,7 @@ from goblet.test_utils import dummy_function
 from pytest import raises
 from goblet_gcp_client import get_response, get_responses
 
-# from goblet.infrastructures.vpcconnector import VPCConnector
-# from goblet.resources.http import HTTP
-
-# TODO revisit VPC Connector deploy once Discovery Document is updated
+from goblet.infrastructures.vpcconnector import VPCConnector
 
 
 class TestVPCConnector:
@@ -37,11 +34,11 @@ class TestVPCConnector:
         )
         app.vpcconnector(name="vpc-test")
 
-        # app.deploy(
-        #     force=True,
-        #     skip_backend=True,
-        #     skip_resources=True,
-        # )
+        app.deploy(
+            force=True,
+            skip_backend=True,
+            skip_resources=True,
+        )
 
         vpc_conn = get_response(
             "vpcconnector-deploy",
@@ -57,8 +54,8 @@ class TestVPCConnector:
         monkeypatch.setenv("G_TEST_NAME", "vpcconnector-destroy")
         monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
 
-        # vpc = VPCConnector("goblet-vpc", resource={"name": "vpc-test"))
-        # vpc.destroy()
+        vpc = VPCConnector("goblet-vpc", resource={"name": "vpc-test"})
+        vpc.destroy()
 
         responses = get_responses("vpcconnector-destroy")
         assert len(responses) == 2
@@ -82,13 +79,13 @@ class TestVPCConnector:
         app.handlers["http"].register("", dummy_function, {})
 
         app.vpcconnector(name="vpc-test")
-        # app.deploy(
-        #     skip_infra=True,
-        #     skip_resources=True,
-        #     force=True,
-        # )
+        app.deploy(
+            skip_infra=True,
+            skip_resources=True,
+            force=True,
+        )
 
-        # app.destroy(skip_infra=True)
+        app.destroy(skip_infra=True)
         response = get_response(
             "vpcconnector-deploy-cloudrun",
             "post-v2-projects-goblet-locations-us-central1-services_1.json",
@@ -116,13 +113,13 @@ class TestVPCConnector:
         app.handlers["http"].register("", dummy_function, {})
 
         app.vpcconnector(name="vpc-test")
-        # app.deploy(
-        #     skip_resources=True,
-        #     skip_infra=True,
-        #     force=True,
-        # )
+        app.deploy(
+            skip_resources=True,
+            skip_infra=True,
+            force=True,
+        )
 
-        # app.destroy(skip_infra=True)
+        app.destroy(skip_infra=True)
         response = get_response(
             "vpcconnector-deploy-function",
             "post-v1-projects-goblet-locations-us-central1-functions_1.json",
@@ -148,13 +145,13 @@ class TestVPCConnector:
         app.handlers["http"].register("", dummy_function, {})
 
         app.vpcconnector(name="vpc-test")
-        # app.deploy(
-        #     skip_resources=True,
-        #     skip_infra=True,
-        #     force=True,
-        # )
+        app.deploy(
+            skip_resources=True,
+            skip_infra=True,
+            force=True,
+        )
 
-        # app.destroy(skip_infra=True)
+        app.destroy(skip_infra=True)
         response = get_response(
             "vpcconnector-deploy-functionv2",
             "get-v2-projects-goblet-locations-us-central1-operations-operation-1664907376650-5ea3974c4e78a-ad732159-2582b07a_1.json",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ pydantic==1.10.2
 PyYAML==6.0
 markupsafe==2.0.1
 google-cloud-logging==3.5.0
-google-api-python-client==2.55.0
 # goblet-gcp-client==0.1.4
 protobuf==3.20.3
 git+https://github.com/qua-jones/goblet_gcp_client@update-api-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,6 @@ marshmallow==3.15.0
 pydantic==1.10.2
 PyYAML==6.0
 markupsafe==2.0.1
-google-cloud-logging==3.5.0
-google-api-python-client==2.86.0
-# goblet-gcp-client==0.1.4
+google-cloud-logging==3.1.2
 protobuf==3.20.3
 git+https://github.com/qua-jones/goblet_gcp_client@update-api-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pydantic==1.10.2
 PyYAML==6.0
 markupsafe==2.0.1
 google-cloud-logging==3.5.0
+google-api-python-client==2.86.0
 # goblet-gcp-client==0.1.4
 protobuf==3.20.3
 git+https://github.com/qua-jones/goblet_gcp_client@update-api-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ PyYAML==6.0
 markupsafe==2.0.1
 google-cloud-logging==3.1.2
 google-api-python-client==2.55.0
-goblet-gcp-client==0.1.3
+# goblet-gcp-client==0.1.4
 protobuf==3.20.3
+git+https://github.com/qua-jones/goblet_gcp_client@update-api-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ marshmallow==3.15.0
 pydantic==1.10.2
 PyYAML==6.0
 markupsafe==2.0.1
-google-cloud-logging==3.1.2
+google-cloud-logging==3.5.0
+google-cloud-appengine-logging==1.3.0
 protobuf==3.20.3
 git+https://github.com/qua-jones/goblet_gcp_client@update-api-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ marshmallow==3.15.0
 pydantic==1.10.2
 PyYAML==6.0
 markupsafe==2.0.1
-google-cloud-logging==3.1.2
+google-cloud-logging==3.5.0
 google-api-python-client==2.55.0
 # goblet-gcp-client==0.1.4
 protobuf==3.20.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ PyYAML==6.0
 markupsafe==2.0.1
 google-cloud-logging==3.5.0
 google-cloud-appengine-logging==1.3.0
+goblet-gcp-client==0.1.4
 protobuf==3.20.3
-git+https://github.com/qua-jones/goblet_gcp_client@update-api-client


### PR DESCRIPTION
- enable vpc connector deploy testing
- requires https://github.com/goblet/goblet_gcp_client/pull/13
- closes #307 