### PR TITLE
[cli] add flags to manage specific resources

### DIFF
--- a/goblet/app.py
+++ b/goblet/app.py
@@ -95,12 +95,9 @@ class Goblet(Goblet_Decorators, Resource_Manager):
         source = None
         backend = self.backend
 
-        if infras:
+        if infras or not skip_infra:
             log.info("deploying infrastructure")
             self.deploy_infrastructure(infras)
-        elif not skip_infra:
-            log.info("deploying infrastructure")
-            self.deploy_infrastructure()
 
         infra_config = self.get_infrastructure_config()
         backend.update_config(infra_config, write_config, stage)
@@ -121,12 +118,9 @@ class Goblet(Goblet_Decorators, Resource_Manager):
             log.error("backend is not deployed, handlers cannot be deployed. exiting.")
             sys.exit(1)
 
-        if handlers:
-            log.info(f"deploying {handlers} handlers")
+        if handlers or not skip_handlers:
+            log.info(f"deploying handlers")
             self.deploy_handlers(source, handlers)
-        elif not skip_handlers:
-            log.info("deploying handlers")
-            self.deploy_handlers(source)
 
     def destroy(
         self,
@@ -139,22 +133,16 @@ class Goblet(Goblet_Decorators, Resource_Manager):
     ):
         """Destroys http cloudfunction and then calls goblet.destroy() to remove handler's infrastructure"""
 
-        if handlers:
-            log.info(f"destroying {handlers} handlers")
-            self.destroy_handlers(handlers)
-        elif not skip_handlers:
+        if handlers or not skip_handlers:
             log.info("destroying handlers")
-            self.destroy_handlers()
+            self.destroy_handlers(handlers)
 
         if not skip_backend:
             self.backend.destroy(all=all)
 
-        if infras:
-            log.info(f"destroying {infras} infrastructure")
+        if infras or not skip_infra:
+            log.info(f"destroying infrastructure")
             self.destroy_infrastructure(infras)
-        elif not skip_infra:
-            log.info("destroying infrastructure")
-            self.destroy_infrastructure()
 
     def sync(
         self,
@@ -164,19 +152,12 @@ class Goblet(Goblet_Decorators, Resource_Manager):
         handlers: List[str] = None,
         infras: List[str] = None,
     ):
-        if infras:
-            log.info(f"syncing {infras} infrastructure")
+        if infras or not skip_infra:
+            log.info(f"syncing infrastructure")
             self.sync_infrastructure(dryrun, infras)
-        elif not skip_infra:
-            log.info("syncing infrastructure")
-            self.sync_infrastructure(dryrun)
-
-        if handlers:
-            log.info(f"syncing {handlers} handlers")
+        if handlers or not skip_handlers:
+            log.info(f"syncing handlers")
             self.sync_handlers(dryrun, handlers)
-        elif not skip_handlers:
-            log.info("syncing handlers")
-            self.sync_handlers(dryrun)
 
     def check_or_enable_services(self, enable=False):
         self.backend._check_or_enable_service(enable)

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -113,8 +113,9 @@ class Goblet(Goblet_Decorators, Resource_Manager):
         # checks registered deployable handlers before determining if backend exists
         if (
             registered_handlers
-            and not backend.get()
+            and skip_backend
             and (handlers or not skip_handlers)
+            and not backend.get()
         ):
             log.error("backend is not deployed, handlers cannot be deployed. exiting.")
             sys.exit(1)

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -10,6 +10,7 @@ from goblet.resource_manager import Resource_Manager
 
 from google.cloud.logging.handlers import StructuredLogHandler
 from google.cloud.logging_v2.handlers import setup_logging
+from typing import List
 
 logging.basicConfig()
 
@@ -133,8 +134,8 @@ class Goblet(Goblet_Decorators, Resource_Manager):
         skip_infra=False,
         skip_handlers=False,
         skip_backend=False,
-        handlers: list[str] = None,
-        infras: list[str] = None,
+        handlers: List[str] = None,
+        infras: List[str] = None,
     ):
         """Destroys http cloudfunction and then calls goblet.destroy() to remove handler's infrastructure"""
 
@@ -160,8 +161,8 @@ class Goblet(Goblet_Decorators, Resource_Manager):
         dryrun=False,
         skip_infra=False,
         skip_handlers=False,
-        handlers: list[str] = None,
-        infras: list[str] = None,
+        handlers: List[str] = None,
+        infras: List[str] = None,
     ):
         if infras:
             log.info(f"syncing {infras} infrastructure")

--- a/goblet/app.py
+++ b/goblet/app.py
@@ -119,7 +119,7 @@ class Goblet(Goblet_Decorators, Resource_Manager):
             sys.exit(1)
 
         if handlers or not skip_handlers:
-            log.info(f"deploying handlers")
+            log.info("deploying handlers")
             self.deploy_handlers(source, handlers)
 
     def destroy(
@@ -141,7 +141,7 @@ class Goblet(Goblet_Decorators, Resource_Manager):
             self.backend.destroy(all=all)
 
         if infras or not skip_infra:
-            log.info(f"destroying infrastructure")
+            log.info("destroying infrastructure")
             self.destroy_infrastructure(infras)
 
     def sync(
@@ -153,10 +153,10 @@ class Goblet(Goblet_Decorators, Resource_Manager):
         infras: List[str] = None,
     ):
         if infras or not skip_infra:
-            log.info(f"syncing infrastructure")
+            log.info("syncing infrastructure")
             self.sync_infrastructure(dryrun, infras)
         if handlers or not skip_handlers:
-            log.info(f"syncing handlers")
+            log.info("syncing handlers")
             self.sync_handlers(dryrun, handlers)
 
     def check_or_enable_services(self, enable=False):

--- a/goblet/handlers/handler.py
+++ b/goblet/handlers/handler.py
@@ -72,3 +72,8 @@ class Handler:
         if not self.resources:
             return
         return check_or_enable_service(self.required_apis, enable)
+
+    def get_resource_type(self):
+        if not self.resources:
+            return
+        return self.resource_type

--- a/goblet/handlers/handler.py
+++ b/goblet/handlers/handler.py
@@ -72,8 +72,3 @@ class Handler:
         if not self.resources:
             return
         return check_or_enable_service(self.required_apis, enable)
-
-    def get_resource_type(self):
-        if not self.resources:
-            return
-        return self.resource_type

--- a/goblet/resource_manager.py
+++ b/goblet/resource_manager.py
@@ -27,6 +27,8 @@ from goblet.infrastructures.cloudtask import CloudTaskQueue
 
 import goblet.globals as g
 
+from typing import List
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.getLevelName(os.getenv("GOBLET_LOG_LEVEL", "INFO")))
 
@@ -222,7 +224,7 @@ class Resource_Manager:
                 resource_types.append(resource_type)
         return resource_types
 
-    def deploy_handlers(self, source, handlers: list[str] = None):
+    def deploy_handlers(self, source, handlers: List[str] = None):
         """Call each handlers deploy method"""
         if handlers:
             for handler in handlers:
@@ -235,11 +237,11 @@ class Resource_Manager:
                 log.info(f"deploying {k}")
                 v.deploy(source, entrypoint="goblet_entrypoint")
 
-    def destroy_handlers(self, handlers: list[str] = None):
+    def destroy_handlers(self, handlers: List[str] = None):
         """Call each handlers destroy method
 
         Args:
-            handlers (list[str], optional):
+            handlers (List[str], optional):
                 List of handler resources, if supplied will only target specified resource.
         """
         if handlers:
@@ -251,7 +253,7 @@ class Resource_Manager:
                 log.info(f"destroying {k}")
                 v.destroy()
 
-    def sync_handlers(self, dryrun=False, handlers: list[str] = None):
+    def sync_handlers(self, dryrun=False, handlers: List[str] = None):
         if handlers:
             for handler in handlers:
                 try:
@@ -269,7 +271,7 @@ class Resource_Manager:
                         continue
                     raise e
 
-    def deploy_infrastructure(self, infras: list[str] = None):
+    def deploy_infrastructure(self, infras: List[str] = None):
         """Call deploy for each infrastructure"""
         if infras:
             for infra in infras:
@@ -280,11 +282,11 @@ class Resource_Manager:
                 log.info(f"deploying {k}")
                 v.deploy()
 
-    def destroy_infrastructure(self, infras: list[str] = None):
+    def destroy_infrastructure(self, infras: List[str] = None):
         """Call destroy method for each infrastructure resource
 
         Args:
-            infras (list[str], optional):
+            infras (List[str], optional):
                 List of infrastructure resources, if supplied will only target specified resource.
         """
         if infras:
@@ -296,7 +298,7 @@ class Resource_Manager:
                 log.info(f"destroying {k}")
                 v.destroy()
 
-    def sync_infrastructure(self, dryrun=False, infras: list[str] = None):
+    def sync_infrastructure(self, dryrun=False, infras: List[str] = None):
         if infras:
             for infra in infras:
                 try:

--- a/goblet/resource_manager.py
+++ b/goblet/resource_manager.py
@@ -213,37 +213,106 @@ class Resource_Manager:
                 configs.append(config)
         return configs
 
-    def deploy_handlers(self, source):
-        """Call each handlers deploy method"""
-        for k, v in self.handlers.items():
-            log.info(f"deploying {k}")
-            v.deploy(source, entrypoint="goblet_entrypoint")
-
-    def deploy_infrastructure(self):
-        """Call deploy for each infrastructure"""
-        for k, v in self.infrastructure.items():
-            log.info(f"deploying {k}")
-            v.deploy()
-
-    def sync(self, dryrun=False):
-        """Call each handlers sync method"""
-        # Sync Infrastructure
-        for _, v in self.infrastructure.items():
-            try:
-                v.sync(dryrun)
-            except HttpError as e:
-                if e.resp.status == 403:
-                    continue
-                raise e
-
-        # Sync Handlers
+    def get_registered_handler_resource_types(self):
+        """Get resource types for all deployable registered handlers, http is only non deployable resource"""
+        resource_types = []
         for _, v in self.handlers.items():
-            try:
-                v.sync(dryrun)
-            except HttpError as e:
-                if e.resp.status == 403:
-                    continue
-                raise e
+            resource_type = v.get_resource_type()
+            if resource_type and resource_type != "http":
+                resource_types.append(resource_type)
+        return resource_types
+
+    def deploy_handlers(self, source, handlers: list[str] = None):
+        """Call each handlers deploy method"""
+        if handlers:
+            for handler in handlers:
+                log.info(f"deploying {handler}")
+                self.handlers.get(handler).deploy(
+                    source, entrypoint="goblet_entrypoint"
+                )
+        else:
+            for k, v in self.handlers.items():
+                log.info(f"deploying {k}")
+                v.deploy(source, entrypoint="goblet_entrypoint")
+
+    def destroy_handlers(self, handlers: list[str] = None):
+        """Call each handlers destroy method
+
+        Args:
+            handlers (list[str], optional):
+                List of handler resources, if supplied will only target specified resource.
+        """
+        if handlers:
+            for handler in handlers:
+                log.info(f"destroying {handler}")
+                self.handlers.get(handler).destroy()
+        else:
+            for k, v in self.handlers.items():
+                log.info(f"destroying {k}")
+                v.destroy()
+
+    def sync_handlers(self, dryrun=False, handlers: list[str] = None):
+        if handlers:
+            for handler in handlers:
+                try:
+                    self.handlers.get(handler).sync(dryrun)
+                except HttpError as e:
+                    if e.resp.status == 403:
+                        continue
+                    raise e
+        else:
+            for _, v in self.handlers.items():
+                try:
+                    v.sync(dryrun)
+                except HttpError as e:
+                    if e.resp.status == 403:
+                        continue
+                    raise e
+
+    def deploy_infrastructure(self, infras: list[str] = None):
+        """Call deploy for each infrastructure"""
+        if infras:
+            for infra in infras:
+                log.info(f"deploying {infra}")
+                self.infrastructure.get(infra).deploy()
+        else:
+            for k, v in self.infrastructure.items():
+                log.info(f"deploying {k}")
+                v.deploy()
+
+    def destroy_infrastructure(self, infras: list[str] = None):
+        """Call destroy method for each infrastructure resource
+
+        Args:
+            infras (list[str], optional):
+                List of infrastructure resources, if supplied will only target specified resource.
+        """
+        if infras:
+            for infra in infras:
+                log.info(f"destroying {infra}")
+                self.infrastructure.get(infra).destroy()
+        else:
+            for k, v in self.infrastructure.items():
+                log.info(f"destroying {k}")
+                v.destroy()
+
+    def sync_infrastructure(self, dryrun=False, infras: list[str] = None):
+        if infras:
+            for infra in infras:
+                try:
+                    self.infrastructure.get(infra).sync(dryrun)
+                except HttpError as e:
+                    if e.resp.status == 403:
+                        continue
+                    raise e
+        else:
+            for _, v in self.infrastructure.items():
+                try:
+                    v.sync(dryrun)
+                except HttpError as e:
+                    if e.resp.status == 403:
+                        continue
+                    raise e
 
     def is_http(self):
         """Is http determines if additional cloudfunctions will be needed since triggers other than http will require their own

--- a/goblet/resource_manager.py
+++ b/goblet/resource_manager.py
@@ -219,9 +219,8 @@ class Resource_Manager:
         """Get resource types for all deployable registered handlers, http is only non deployable resource"""
         resource_types = []
         for _, v in self.handlers.items():
-            resource_type = v.get_resource_type()
-            if resource_type and resource_type != "http":
-                resource_types.append(resource_type)
+            if v.resource_type != "http" and v.resources:
+                resource_types.append(resource_types)
         return resource_types
 
     def deploy_handlers(self, source, handlers: List[str] = None):

--- a/goblet/tests/data/http/routes-deploy-without-backend/get-v1-projects-goblet-locations-us-central1-functions-goblet-routes_1.json
+++ b/goblet/tests/data/http/routes-deploy-without-backend/get-v1-projects-goblet-locations-us-central1-functions-goblet-routes_1.json
@@ -1,0 +1,10 @@
+{
+  "headers": {},
+  "body": {
+    "error": {
+      "code": 404,
+      "message": "Function goblet-routes in region us-central1 in project goblet does not exist",
+      "status": "NOT_FOUND"
+    }
+  }
+}

--- a/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-connectors-vpc-test_1.json
+++ b/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-connectors-vpc-test_1.json
@@ -1,14 +1,14 @@
 {
   "headers": {},
   "body": {
-    "name": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test",
+    "name": "projects/goblet/locations/us-central1/connectors/vpc-test",
     "network": "default",
     "ipCidrRange": "10.32.1.0/28",
     "state": "READY",
     "minThroughput": 200,
     "maxThroughput": 300,
     "connectedProjects": [
-      "premise-governance-rd"
+      "goblet"
     ],
     "machineType": "e2-micro",
     "minInstances": 2,

--- a/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-connectors-vpc-test_1.json
+++ b/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-connectors-vpc-test_1.json
@@ -1,0 +1,17 @@
+{
+  "headers": {},
+  "body": {
+    "name": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test",
+    "network": "default",
+    "ipCidrRange": "10.32.1.0/28",
+    "state": "READY",
+    "minThroughput": 200,
+    "maxThroughput": 300,
+    "connectedProjects": [
+      "premise-governance-rd"
+    ],
+    "machineType": "e2-micro",
+    "minInstances": 2,
+    "maxInstances": 3
+  }
+}

--- a/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-operations-ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c_1.json
+++ b/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-operations-ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c_1.json
@@ -1,18 +1,18 @@
 {
   "headers": {},
   "body": {
-    "name": "projects/premise-governance-rd/locations/us-central1/operations/ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c",
+    "name": "projects/goblet/locations/us-central1/operations/ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c",
     "metadata": {
       "@type": "type.googleapis.com/google.cloud.vpcaccess.v1.OperationMetadata",
       "method": "google.cloud.vpcaccess.v1.VpcAccessService.CreateConnector",
       "createTime": "2023-05-26T16:48:10.262669Z",
       "endTime": "2023-05-26T16:49:53.570489Z",
-      "target": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test"
+      "target": "projects/goblet/locations/us-central1/connectors/vpc-test"
     },
     "done": true,
     "response": {
       "@type": "type.googleapis.com/google.cloud.vpcaccess.v1.Connector",
-      "name": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test",
+      "name": "projects/goblet/locations/us-central1/connectors/vpc-test",
       "network": "default",
       "ipCidrRange": "10.32.1.0/28",
       "state": "READY",

--- a/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-operations-ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c_1.json
+++ b/goblet/tests/data/http/vpcconnector-deploy-solo/get-v1-projects-goblet-locations-us-central1-operations-ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c_1.json
@@ -1,0 +1,26 @@
+{
+  "headers": {},
+  "body": {
+    "name": "projects/premise-governance-rd/locations/us-central1/operations/ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.vpcaccess.v1.OperationMetadata",
+      "method": "google.cloud.vpcaccess.v1.VpcAccessService.CreateConnector",
+      "createTime": "2023-05-26T16:48:10.262669Z",
+      "endTime": "2023-05-26T16:49:53.570489Z",
+      "target": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test"
+    },
+    "done": true,
+    "response": {
+      "@type": "type.googleapis.com/google.cloud.vpcaccess.v1.Connector",
+      "name": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test",
+      "network": "default",
+      "ipCidrRange": "10.32.1.0/28",
+      "state": "READY",
+      "minThroughput": 200,
+      "maxThroughput": 300,
+      "machineType": "e2-micro",
+      "minInstances": 2,
+      "maxInstances": 3
+    }
+  }
+}

--- a/goblet/tests/data/http/vpcconnector-deploy-solo/post-v1-projects-goblet-locations-us-central1-connectors_1.json
+++ b/goblet/tests/data/http/vpcconnector-deploy-solo/post-v1-projects-goblet-locations-us-central1-connectors_1.json
@@ -1,0 +1,12 @@
+{
+  "headers": {},
+  "body": {
+    "name": "projects/premise-governance-rd/locations/us-central1/operations/ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c",
+    "metadata": {
+      "@type": "type.googleapis.com/google.cloud.vpcaccess.v1.OperationMetadata",
+      "method": "google.cloud.vpcaccess.v1.VpcAccessService.CreateConnector",
+      "createTime": "2023-05-26T16:48:10.262669Z",
+      "target": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test"
+    }
+  }
+}

--- a/goblet/tests/data/http/vpcconnector-deploy-solo/post-v1-projects-goblet-locations-us-central1-connectors_1.json
+++ b/goblet/tests/data/http/vpcconnector-deploy-solo/post-v1-projects-goblet-locations-us-central1-connectors_1.json
@@ -1,12 +1,12 @@
 {
   "headers": {},
   "body": {
-    "name": "projects/premise-governance-rd/locations/us-central1/operations/ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c",
+    "name": "projects/goblet/locations/us-central1/operations/ccbd4475-81a7-41cf-abcd-beb8ec7c2d7c",
     "metadata": {
       "@type": "type.googleapis.com/google.cloud.vpcaccess.v1.OperationMetadata",
       "method": "google.cloud.vpcaccess.v1.VpcAccessService.CreateConnector",
       "createTime": "2023-05-26T16:48:10.262669Z",
-      "target": "projects/premise-governance-rd/locations/us-central1/connectors/vpc-test"
+      "target": "projects/goblet/locations/us-central1/connectors/vpc-test"
     }
   }
 }

--- a/goblet/tests/test_apigateway.py
+++ b/goblet/tests/test_apigateway.py
@@ -87,6 +87,6 @@ class TestApiGatewayExisting:
 
         app = Goblet("goblet_routes")
         app.apigateway("goblet-routes", "URL", openapi_dict=openapi_dict)
-        app.deploy(force=True, skip_resources=True, skip_backend=True)
+        app.deploy(force=True, skip_handlers=True, skip_backend=True)
 
         assert get_replay_count() == 7

--- a/goblet/tests/test_cloudtasks.py
+++ b/goblet/tests/test_cloudtasks.py
@@ -39,7 +39,7 @@ class TestCloudTasks:
         app.deploy(
             force=True,
             skip_backend=True,
-            skip_resources=True,
+            skip_handlers=True,
         )
 
         post_cloudtaskqueue = get_response(
@@ -89,7 +89,7 @@ class TestCloudTasks:
         app.deploy(
             force=True,
             skip_backend=True,
-            skip_resources=True,
+            skip_handlers=True,
         )
 
         @app.cloudtasktarget(name="target")

--- a/goblet/tests/test_deployer.py
+++ b/goblet/tests/test_deployer.py
@@ -20,7 +20,7 @@ class TestDeployer:
 
         app.handlers["http"] = HTTP("name", app)
 
-        app.deploy(skip_resources=True, skip_infra=True, force=True)
+        app.deploy(skip_handlers=True, skip_infra=True, force=True)
 
         responses = get_responses("deployer-function-deploy")
         assert len(responses) == 3
@@ -42,7 +42,7 @@ class TestDeployer:
 
         app.handlers["http"].register("", dummy_function, {})
 
-        app.deploy(skip_resources=True, skip_infra=True, force=True)
+        app.deploy(skip_handlers=True, skip_infra=True, force=True)
 
         responses = get_responses("deployer-function-deploy-v2")
         assert len(responses) == 3
@@ -68,7 +68,7 @@ class TestDeployer:
 
         app.handlers["http"] = HTTP("name", app)
 
-        app.deploy(skip_resources=True, skip_infra=True, force=True)
+        app.deploy(skip_handlers=True, skip_infra=True, force=True)
 
         responses = get_responses("deployer-cloudrun-deploy")
         assert len(responses) == 9
@@ -94,7 +94,7 @@ class TestDeployer:
 
         app.handlers["http"] = HTTP("name", app)
         with pytest.raises(GobletError):
-            app.deploy(skip_resources=True, skip_infra=True, force=True)
+            app.deploy(skip_handlers=True, skip_infra=True, force=True)
 
     def test_destroy_cloudrun(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
@@ -160,7 +160,7 @@ class TestDeployer:
 
         app.handlers["http"] = HTTP("name", app)
         app.deploy(
-            skip_resources=True,
+            skip_handlers=True,
             skip_infra=True,
             force=True,
         )
@@ -214,7 +214,7 @@ class TestDeployer:
         app.handlers["http"] = HTTP("name", app)
 
         app.deploy(
-            skip_resources=True,
+            skip_handlers=True,
             skip_infra=True,
             force=True,
         )
@@ -254,7 +254,7 @@ class TestDeployer:
 
         app.handlers["http"] = HTTP("name", app, resources=[{}])
 
-        app.deploy(skip_resources=True, skip_infra=True, force=True)
+        app.deploy(skip_handlers=True, skip_infra=True, force=True)
 
         response = get_response(
             G_TEST_NAME, "post-v2-projects-goblet-locations-us-central1-services_1.json"

--- a/goblet/tests/test_redis.py
+++ b/goblet/tests/test_redis.py
@@ -34,7 +34,7 @@ class TestRedis:
         )
         app.redis(name="redis-test")
 
-        app.deploy(force=True, skip_backend=True, skip_resources=True)
+        app.deploy(force=True, skip_backend=True, skip_handlers=True)
 
         post_redis = get_response(
             "redis-deploy",
@@ -61,7 +61,7 @@ class TestRedis:
         )
         app.redis(name="redis-test")
 
-        app.deploy(force=True, skip_backend=True, skip_resources=True)
+        app.deploy(force=True, skip_backend=True, skip_handlers=True)
 
         redis_response = get_response(
             "redis-update",
@@ -112,7 +112,7 @@ class TestRedis:
 
         app.handlers["http"].register("", dummy_function, {})
 
-        app.deploy(skip_resources=True, skip_infra=True)
+        app.deploy(skip_handlers=True, skip_infra=True)
         app.destroy(skip_infra=True)
 
         cloudrun_response = get_response(
@@ -161,7 +161,7 @@ class TestRedis:
         app.handlers["http"].register("", dummy_function, {})
 
         app.deploy(
-            skip_resources=True,
+            skip_handlers=True,
             skip_infra=True,
         )
         app.destroy(skip_infra=True)
@@ -202,7 +202,7 @@ class TestRedis:
         app.redis(name="redis-test")
         app.handlers["http"].register("", dummy_function, {})
 
-        app.deploy(skip_resources=True, skip_infra=True)
+        app.deploy(skip_handlers=True, skip_infra=True)
         app.destroy(skip_infra=True)
 
         responses = get_responses("redis-deploy-functionv2")

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -275,3 +275,16 @@ class TestRoutes:
         assert responses[1]["body"]["metadata"]["target"].endswith("goblet-routes")
         assert responses[2]["body"]["metadata"]["verb"] == "delete"
         assert responses[2]["body"]["metadata"]["target"].endswith("goblet-routes")
+
+    def test_deploy_routes_without_backend(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("G_TEST_NAME", "routes-deploy-without-backend")
+        monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
+
+        app = Goblet("goblet-routes")
+        app.route("/home")(dummy_function)
+
+        with pytest.raises(SystemExit) as e:
+            app.deploy(handlers=["routes"], skip_backend=True)
+        assert e.value.code == 1

--- a/goblet/tests/test_vpcconnector.py
+++ b/goblet/tests/test_vpcconnector.py
@@ -1,3 +1,4 @@
+import pytest
 from goblet import Goblet
 from goblet.test_utils import dummy_function
 from pytest import raises
@@ -164,3 +165,31 @@ class TestVPCConnector:
             == function_v2_metadata["serviceConfig"]["vpcConnectorEgressSettings"]
         )
         assert "vpc-test" in function_v2_metadata["serviceConfig"]["vpcConnector"]
+
+    def test_deploy_vpcconnector_solo(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_PROJECT", "goblet")
+        monkeypatch.setenv("GOOGLE_LOCATION", "us-central1")
+        monkeypatch.setenv("G_TEST_NAME", "vpcconnector-deploy-solo")
+        monkeypatch.setenv("G_HTTP_TEST", "REPLAY")
+
+        app = Goblet(
+            function_name="goblet-example",
+            config={"vpcconnector": {"ipCidrRange": "10.32.1.0/28"}},
+            backend="cloudrun",
+        )
+        app.vpcconnector(name="vpc-test")
+        app.job(name="job-test")(dummy_function)
+
+        app.deploy(
+            force=True, infras=["vpcconnector"], skip_backend=True, skip_handlers=True
+        )
+
+        responses = get_responses("vpcconnector-deploy-solo")
+        assert len(responses) == 3
+        assert "vpc-test" in responses[0]["body"]["name"]
+
+        with pytest.raises(FileNotFoundError) as _:
+            get_response(
+                "vpcconnector-deploy-solo",
+                "post-v2-projects-goblet-locations-us-central1-jobs_1.json",
+            )

--- a/goblet/tests/test_vpcconnector.py
+++ b/goblet/tests/test_vpcconnector.py
@@ -37,7 +37,7 @@ class TestVPCConnector:
         app.deploy(
             force=True,
             skip_backend=True,
-            skip_resources=True,
+            skip_handlers=True,
         )
 
         vpc_conn = get_response(
@@ -81,7 +81,7 @@ class TestVPCConnector:
         app.vpcconnector(name="vpc-test")
         app.deploy(
             skip_infra=True,
-            skip_resources=True,
+            skip_handlers=True,
             force=True,
         )
 
@@ -114,7 +114,7 @@ class TestVPCConnector:
 
         app.vpcconnector(name="vpc-test")
         app.deploy(
-            skip_resources=True,
+            skip_handlers=True,
             skip_infra=True,
             force=True,
         )
@@ -146,7 +146,7 @@ class TestVPCConnector:
 
         app.vpcconnector(name="vpc-test")
         app.deploy(
-            skip_resources=True,
+            skip_handlers=True,
             skip_infra=True,
             force=True,
         )


### PR DESCRIPTION
addresses #304 

- **BREAKING**: update `skip-resources` flag to be `skip-handlers`
- add option to deploy, destroy, and sync one or more handler resources with flag `-h / --handler`
- add option to deploy, destroy, and sync one or more infrastructure resources with flag `-i / --infra`
- add flags `skip-backend` and `skip-handlers` to destroy command
- add check to verify backend is deployed if handlers are being deployed

```
goblet deploy -l us-central1 -h jobs -i alerts --skip-backend
goblet sync -l us-central1 -h jobs --skip-infra --skip-backend
goblet destroy -l us-central1 -i alerts --skip-handlers --skip-backend
```
