### PR TITLE
[alerts] allow log match condition filter to be replaced instead of concatenated

### DIFF
--- a/docs/source/infrastructures.rst
+++ b/docs/source/infrastructures.rst
@@ -17,6 +17,8 @@ If you do not need a fully customized alert you can use the built in classes for
 defaults in terms of duration and aggregations, but can be overriden as needed. The `CustomMetricCondition` creates a custom metric based on the filter provided and then 
 creates an alert using that metric.  
 
+For `LogMatchCondition` you can completely replace the filter if necessary by setting the `replace_filter` flag to True. 
+
 .. code:: python
 
     from goblet.infrastructures.alerts import MetricCondition,LogMatchCondition,CustomMetricCondition

--- a/goblet/infrastructures/alerts.py
+++ b/goblet/infrastructures/alerts.py
@@ -340,7 +340,9 @@ class LogMatchCondition(AlertCondition):
         super().__init__(
             name=name,
             log_match={
-                "filter": 'resource.type="{monitoring_type}"\nresource.labels.{monitoring_label_key}="{resource_name}"\n'
+                "filter": filter
+                if kwargs.get("replace_filter", False)
+                else 'resource.type="{monitoring_type}"\nresource.labels.{monitoring_label_key}="{resource_name}"\n'
                 + filter
             },
         )


### PR DESCRIPTION
- gives more flexibility to log matching alerts not tied to a deployed resource within the same app