### PR TITLE
Create a local copy of config.cloudbuild instead of assigning a reference in CloudRun.create_build()

### DIFF
--- a/goblet/backends/cloudrun.py
+++ b/goblet/backends/cloudrun.py
@@ -123,7 +123,7 @@ class CloudRun(Backend):
 
     def create_build(self, client, source=None, name="goblet"):
         """Creates http cloudbuild"""
-        build_configs = self.config.cloudbuild or {}
+        build_configs = self.config.cloudbuild.copy() if self.config.cloudbuild else {}
         registry = build_configs.get("artifact_registry") or getDefaultRegistry(name)
         build_configs.pop("artifact_registry", None)
 


### PR DESCRIPTION
Currently within the `CloudRun.create_build()` function, the `self.config.cloudbuild` reference is assigned to the `build_configs` variable. As a result, when `artifact_registry` is removed from the config (`build_configs.pop("artifact_registry", None)`), it becomes unavailable in later deployment steps.

Suggested fix: copy `config.cloudbuild` dict