### PR TITLE
upgrade GConfig to handle nested __getattr__

### DIFF
--- a/goblet/config.py
+++ b/goblet/config.py
@@ -72,7 +72,7 @@ class GConfig(dict):
         if os.environ.get(name):
             return os.environ.get(name)
         attr = self.config.get(name)
-        if type(attr) == dict and len(attr) > 0:
+        if isinstance(attr, dict) and len(attr) > 0:
             return GConfig(config=attr, init=False)
         if attr is None:
             return GConfig(config={}, init=False)

--- a/goblet/config.py
+++ b/goblet/config.py
@@ -59,9 +59,6 @@ class GConfig(dict):
             )
             return {}
 
-    def keys(self):
-        return self.config.keys()
-
     def __getitem__(self, item):
         return getattr(self, item)
 
@@ -79,24 +76,6 @@ class GConfig(dict):
         if attr or attr == {}:
             return attr
         return None
-
-    def __eq__(self, other):
-        if self.config == other:
-            return True
-        return False
-
-    def __bool__(self):
-        if self.config == {}:
-            return False
-        return True
-
-    def get(self, key, default=None):
-        try:
-            return self.config[key]
-        except TypeError:
-            return default
-        except KeyError:
-            return default
 
     def __setattr__(self, name, value):
         if name not in ["config", "stage"]:

--- a/goblet/tests/test_config.py
+++ b/goblet/tests/test_config.py
@@ -60,3 +60,55 @@ class TestGConfig:
         config = GConfig(test_config)
         config.update_g_config(stage="dev")
         assert config.cloudfunction["environmentVariables"]["key"] == "dev"
+
+    def test_config_assignment(self):
+        config = GConfig(test_config)
+        config.cloudfunction = "new_value"
+        assert config.cloudfunction == "new_value"
+        assert config["cloudfunction"] == "new_value"
+
+        config = GConfig(test_config)
+        config["cloudfunction"] = "new_value"
+        assert config.cloudfunction == "new_value"
+        assert config["cloudfunction"] == "new_value"
+
+        config = GConfig(test_config)
+        config.cloudfunction = {"new_key": "value"}
+        config.cloudfunction.new_key = "new_value"
+        assert config["cloudfunction"]["new_key"] == "new_value"
+
+    def test_unpacking(self):
+        config = GConfig(test_config)
+        new_dict = {**config}
+
+        assert new_dict.get("cloudfunction", False).get(
+            "environmentVariables", False
+        ) == {"key": "value"}
+        assert new_dict["cloudfunction"]["environmentVariables"] == {"key": "value"}
+
+        new_dict = {**config["cloudfunction"]}
+        assert new_dict.get("environmentVariables", False) == {"key": "value"}
+        assert new_dict["environmentVariables"] == {"key": "value"}
+
+        new_dict = {**config.cloudfunction}
+        assert new_dict.get("environmentVariables", False) == {"key": "value"}
+        assert new_dict["environmentVariables"] == {"key": "value"}
+
+    def test_compare(self):
+        config1 = GConfig(test_config)
+        config2 = GConfig(test_config)
+
+        assert id(config1) != id(config2)
+        assert config1 == config2
+        assert config1.stage == config2.stage
+
+    def test_json_dumps(self):
+        import json
+
+        config = GConfig(test_config)
+        assert json.dumps(config, sort_keys=True) == json.dumps(
+            test_config, sort_keys=True
+        )
+        assert json.dumps(config.cloudfunction, sort_keys=True) == json.dumps(
+            test_config["cloudfunction"], sort_keys=True
+        )


### PR DESCRIPTION
GConfig().key1 recursively returns a new GConfig object loaded with the dictionary under key1

Since goblet code expects that most of the output of using GConfig is a dictionary, implemented __eq__, __bool__, __getitem__, __setitem__, get() and keys()

Also subclassed dict to make it JSON Serializable
