### PR TITLE
fix issue [Openapispec] - error creating spec #437

### DIFF
--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -198,6 +198,7 @@ class OpenApiSpec:
         self.deadline = deadline
         self.options["swagger"] = "2.0"
         if security_definitions:
+            security_definitions = {**security_definitions}
             self.options["securityDefinitions"] = security_definitions
             self.options["security"] = security or list(
                 map(lambda s: {s: []}, security_definitions)


### PR DESCRIPTION
unpack security_definitions inside goblet.handlers.routes.OpenApiSpec

make securityDefinitions in openapispec tests GConfig instances test write spec to yaml

add test to write securityDefinitions to yaml