### PR TITLE
Enum Route Param

### DIFF
--- a/examples/example_multi_container/main.py
+++ b/examples/example_multi_container/main.py
@@ -9,6 +9,6 @@ app = Goblet("multi-container", backend="cloudrun", routes_type="cloudrun")
 goblet_entrypoint(app)
 
 
-@app.route('/test', methods=["POST", "GET"])
+@app.route("/test", methods=["POST", "GET"])
 def test():
     return "api container"

--- a/examples/example_pubsub_emulator/main.py
+++ b/examples/example_pubsub_emulator/main.py
@@ -5,11 +5,11 @@ from goblet.infrastructures.pubsub import PubSubClient
 from goblet import Goblet, goblet_entrypoint
 
 # Set the PUBSUB_EMULATOR_HOST environment variable to the emulator's host:port
-os.environ['PUBSUB_EMULATOR_HOST'] = 'localhost:8085'
-os.environ['GOBLET_LOCAL_URL'] = 'http://host.docker.internal:8080'
+os.environ["PUBSUB_EMULATOR_HOST"] = "localhost:8085"
+os.environ["GOBLET_LOCAL_URL"] = "http://host.docker.internal:8080"
 
 # Create a Goblet app
-app = Goblet(function_name='create-pubsub-topic')
+app = Goblet(function_name="create-pubsub-topic")
 
 # Set the log level to DEBUG
 app.log.setLevel(logging.DEBUG)
@@ -17,9 +17,10 @@ app.log.setLevel(logging.DEBUG)
 goblet_entrypoint(app)
 
 # Create a Pub/Sub client
-client: PubSubClient = app.pubsub_topic('goblet-created-test-topic')
+client: PubSubClient = app.pubsub_topic("goblet-created-test-topic")
 
-@app.pubsub_subscription('goblet-created-test-topic', use_subscription=True)
+
+@app.pubsub_subscription("goblet-created-test-topic", use_subscription=True)
 def test_topic_handler(event):
     """
     Handler function for the 'goblet-created-test-topic' Pub/Sub subscription.
@@ -27,16 +28,14 @@ def test_topic_handler(event):
     app.log.info(event)
     return "OK"
 
-@app.route('/send')
+
+@app.route("/send")
 def index():
     """
     Endpoint for sending a test message to the 'goblet-created-test-topic' Pub/Sub topic.
     """
     response = client.publish(
-        message={
-            'message': 'test',
-            'time': datetime.datetime.now().isoformat()
-        }
+        message={"message": "test", "time": datetime.datetime.now().isoformat()}
     )
     app.log.info(response)
     return "ok"

--- a/examples/main.py
+++ b/examples/main.py
@@ -116,6 +116,11 @@ def traffic() -> TrafficStop:
 #         - yellow
 #         - red
 
+# Enum paramter 
+@app.route("/{color}")
+def prim_enum(color: StopLight):
+    return StopLight(color)
+
 # Pydantic Typing
 from pydantic import BaseModel
 

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 12, 1, 1)
+VERSION = (0, 12, 2)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -7,6 +7,7 @@ import re
 from typing import get_type_hints
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from enum import Enum
 
 import goblet
 
@@ -247,6 +248,8 @@ class OpenApiSpec:
             return {"type": "string"}
         if type_info in PRIMITIVE_MAPPINGS.keys():
             param_type = {"type": PRIMITIVE_MAPPINGS[type_info]}
+        elif issubclass(type_info, Enum):
+            param_type = {"type": "string", "enum": [e.value for e in type_info]}
         elif issubclass(type_info, Schema) and not only_primititves:
             self.add_component(type_info, schema=type_info)
             param_type = {"$ref": f"#/definitions/{type_info.__name__}"}


### PR DESCRIPTION
closes #442 
```
class StopLight(Enum):
    green = 'green'
    yellow = 'yellow'
    red = 'red'


@app.route("/{color}")
def prim_enum(color: StopLight):
    return StopLight(color)
```

returns openapi spec as follows

```
      - in: path
        name: color
        required: true
        type: string
        enum:
        - green
        - yellow
        - red
 ```