### PR TITLE
add cloudrun mapping in json schema to CloudRun Service config

### DIFF
--- a/goblet.schema.json
+++ b/goblet.schema.json
@@ -26,6 +26,9 @@
         "cloudfunction_v2": {
           "$ref": "https://raw.githubusercontent.com/goblet/goblet/main/utils/schema/references/cloudfunctions.v2.json#/schemas/Function"
         },
+        "cloudrun": {
+          "$ref": "https://raw.githubusercontent.com/goblet/goblet/main/utils/schema/references/run.v2.json#/schemas/GoogleCloudRunV2Service"
+        },
         "cloudrun_container": {
           "$ref": "https://raw.githubusercontent.com/goblet/goblet/main/utils/schema/references/run.v2.json#/schemas/GoogleCloudRunV2Container"
         },

--- a/utils/schema/base.json
+++ b/utils/schema/base.json
@@ -85,6 +85,9 @@
             }
           }
         },
+        "cloudrun": {
+          "$ref": "https://run.googleapis.com/$discovery/rest?version=v2#/schemas/GoogleCloudRunV2Service"
+        },
         "cloudrun_revision": {
           "$ref": "https://run.googleapis.com/$discovery/rest?version=v2#/schemas/GoogleCloudRunV2Revision"
         },

--- a/utils/schema/references/apigateway.v1.json
+++ b/utils/schema/references/apigateway.v1.json
@@ -1083,7 +1083,7 @@
       }
     }
   },
-  "revision": "20230906",
+  "revision": "20231010",
   "rootUrl": "https://apigateway.googleapis.com/",
   "schemas": {
     "ApigatewayApi": {

--- a/utils/schema/references/cloudbuild.v1.json
+++ b/utils/schema/references/cloudbuild.v1.json
@@ -2319,7 +2319,7 @@
       }
     }
   },
-  "revision": "20230907",
+  "revision": "20231017",
   "rootUrl": "https://cloudbuild.googleapis.com/",
   "schemas": {
     "ApprovalConfig": {
@@ -2593,6 +2593,10 @@
         },
         "peeredNetwork": {
           "description": "Optional. The network to be used when reaching out to the Bitbucket Server instance. The VPC network must be enabled for private service connection. This should be set if the Bitbucket Server instance is hosted on-premises and not reachable by public internet. If this field is left empty, no network peering will occur and calls to the Bitbucket Server instance will be made over the public internet. Must be in the format `projects/{project}/global/networks/{network}`, where {project} is a project number or id and {network} is the name of a VPC network in the project.",
+          "type": "string"
+        },
+        "peeredNetworkIpRange": {
+          "description": "Immutable. IP range within the peered network. This is specified in CIDR notation with a slash and the subnet prefix size. You can optionally specify an IP address before the subnet prefix value. e.g. `192.168.0.0/29` would specify an IP range starting at 192.168.0.0 with a 29 bit prefix size. `/16` would specify a prefix size of 16 bits, with an automatically determined IP within the peered VPC. If unspecified, a value of `/24` will be used. The field only has an effect if peered_network is set.",
           "type": "string"
         },
         "secrets": {
@@ -4969,6 +4973,16 @@
           "readOnly": true,
           "type": "object"
         },
+        "resolvedConnectedRepository": {
+          "$ref": "#/schemas/ConnectedRepository",
+          "description": "Output only. A copy of the build's `source.connected_repository`, if exists, with any revisions resolved.",
+          "readOnly": true
+        },
+        "resolvedGitSource": {
+          "$ref": "#/schemas/GitSource",
+          "description": "Output only. A copy of the build's `source.git_source`, if exists, with any revisions resolved.",
+          "readOnly": true
+        },
         "resolvedRepoSource": {
           "$ref": "#/schemas/RepoSource",
           "description": "A copy of the build's `source.repo_source`, if exists, with any revisions resolved."
@@ -5026,6 +5040,20 @@
         },
         "object": {
           "description": "Cloud Storage object containing the source. This object must be a zipped (`.zip`) or gzipped archive file (`.tar.gz`) containing source to build.",
+          "type": "string"
+        },
+        "sourceFetcher": {
+          "description": "Optional. Option to specify the tool to fetch the source file for the build.",
+          "enum": [
+            "SOURCE_FETCHER_UNSPECIFIED",
+            "GSUTIL",
+            "GCS_FETCHER"
+          ],
+          "enumDescriptions": [
+            "Unspecified defaults to GSUTIL.",
+            "Use the \"gsutil\" tool to download the source file.",
+            "Use the Cloud Storage Fetcher tool to download the source file."
+          ],
           "type": "string"
         }
       },

--- a/utils/schema/references/cloudfunctions.v1.json
+++ b/utils/schema/references/cloudfunctions.v1.json
@@ -372,6 +372,12 @@
                       "pattern": "^projects/[^/]+/locations/[^/]+/functions/[^/]+$",
                       "required": true,
                       "type": "string"
+                    },
+                    "versionId": {
+                      "description": "Optional. The optional version of the function whose details should be obtained. The version of a 1st Gen function is an integer that starts from 1 and gets incremented on redeployments. Each deployment creates a config version of the underlying function. GCF may keep historical configs for old versions. This field can be specified to fetch the historical configs. Leave it blank or set to 0 to get the latest version of the function.",
+                      "format": "int64",
+                      "location": "query",
+                      "type": "string"
                     }
                   },
                   "path": "v1/{+name}",
@@ -546,7 +552,7 @@
       }
     }
   },
-  "revision": "20230907",
+  "revision": "20231012",
   "rootUrl": "https://cloudfunctions.googleapis.com/",
   "schemas": {
     "AuditConfig": {

--- a/utils/schema/references/cloudfunctions.v2.json
+++ b/utils/schema/references/cloudfunctions.v2.json
@@ -571,7 +571,7 @@
       }
     }
   },
-  "revision": "20230907",
+  "revision": "20231012",
   "rootUrl": "https://cloudfunctions.googleapis.com/",
   "schemas": {
     "AuditConfig": {

--- a/utils/schema/references/cloudtasks.v2.json
+++ b/utils/schema/references/cloudtasks.v2.json
@@ -134,6 +134,31 @@
                 "https://www.googleapis.com/auth/cloud-platform"
               ]
             },
+            "getCmekConfig": {
+              "description": "Gets the CMEK config. Gets the Customer Managed Encryption Key configured with the Cloud Tasks lcoation. By default there is no kms_key configured.",
+              "flatPath": "v2/projects/{projectsId}/locations/{locationsId}/cmekConfig",
+              "httpMethod": "GET",
+              "id": "cloudtasks.projects.locations.getCmekConfig",
+              "parameterOrder": [
+                "name"
+              ],
+              "parameters": {
+                "name": {
+                  "description": "Required. The config. For example: projects/PROJECT_ID/locations/LOCATION_ID/CmekConfig`",
+                  "location": "path",
+                  "pattern": "^projects/[^/]+/locations/[^/]+/cmekConfig$",
+                  "required": true,
+                  "type": "string"
+                }
+              },
+              "path": "v2/{+name}",
+              "response": {
+                "$ref": "#/schemas/CmekConfig"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ]
+            },
             "list": {
               "description": "Lists information about the supported locations for this service.",
               "flatPath": "v2/projects/{projectsId}/locations",
@@ -170,6 +195,40 @@
               "path": "v2/{+name}/locations",
               "response": {
                 "$ref": "#/schemas/ListLocationsResponse"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ]
+            },
+            "updateCmekConfig": {
+              "description": "Creates or Updates a CMEK config. Updates the Customer Managed Encryption Key assotiated with the Cloud Tasks location (Creates if the key does not already exist). All new tasks created in the location will be encrypted at-rest with the KMS-key provided in the config.",
+              "flatPath": "v2/projects/{projectsId}/locations/{locationsId}/cmekConfig",
+              "httpMethod": "PATCH",
+              "id": "cloudtasks.projects.locations.updateCmekConfig",
+              "parameterOrder": [
+                "name"
+              ],
+              "parameters": {
+                "name": {
+                  "description": "Output only. The config resource name which includes the project and location and must end in 'cmekConfig', in the format projects/PROJECT_ID/locations/LOCATION_ID/cmekConfig`",
+                  "location": "path",
+                  "pattern": "^projects/[^/]+/locations/[^/]+/cmekConfig$",
+                  "required": true,
+                  "type": "string"
+                },
+                "updateMask": {
+                  "description": "List of fields to be updated in this request.",
+                  "format": "google-fieldmask",
+                  "location": "query",
+                  "type": "string"
+                }
+              },
+              "path": "v2/{+name}",
+              "request": {
+                "$ref": "#/schemas/CmekConfig"
+              },
+              "response": {
+                "$ref": "#/schemas/CmekConfig"
               },
               "scopes": [
                 "https://www.googleapis.com/auth/cloud-platform"
@@ -685,7 +744,7 @@
       }
     }
   },
-  "revision": "20230906",
+  "revision": "20230929",
   "rootUrl": "https://cloudtasks.googleapis.com/",
   "schemas": {
     "AppEngineHttpRequest": {
@@ -805,6 +864,22 @@
         },
         "role": {
           "description": "Role that is assigned to the list of `members`, or principals. For example, `roles/viewer`, `roles/editor`, or `roles/owner`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CmekConfig": {
+      "description": "CMEK, or Customer Managed Encryption Keys, enables GCP products to put control over encryption and key management in their customer\u2019s hands.",
+      "id": "CmekConfig",
+      "properties": {
+        "kmsKey": {
+          "description": "Resource name of the Cloud KMS key, of the form `projects/PROJECT_ID/locations/LOCATION_ID/keyRings/KEY_RING_ID/cryptoKeys/KEY_ID`, that will be used to encrypt the Queues & Tasks in the region. Setting this as blank will turn off CMEK encryption.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Output only. The config resource name which includes the project and location and must end in 'cmekConfig', in the format projects/PROJECT_ID/locations/LOCATION_ID/cmekConfig`",
+          "readOnly": true,
           "type": "string"
         }
       },

--- a/utils/schema/references/redis.v1.json
+++ b/utils/schema/references/redis.v1.json
@@ -177,6 +177,203 @@
             }
           },
           "resources": {
+            "clusters": {
+              "methods": {
+                "create": {
+                  "description": "Creates a Redis cluster based on the specified properties. The creation is executed asynchronously and callers may check the returned operation to track its progress. Once the operation is completed the Redis cluster will be fully functional. The completed longrunning.Operation will contain the new cluster object in the response field. The returned operation is automatically deleted after a few hours, so there is no need to call DeleteOperation.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/clusters",
+                  "httpMethod": "POST",
+                  "id": "redis.projects.locations.clusters.create",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "parameters": {
+                    "clusterId": {
+                      "description": "Required. The logical name of the Redis cluster in the customer project with the following restrictions: * Must contain only lowercase letters, numbers, and hyphens. * Must start with a letter. * Must be between 1-63 characters. * Must end with a number or a letter. * Must be unique within the customer project / location",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "parent": {
+                      "description": "Required. The resource name of the cluster location using the form: `projects/{project_id}/locations/{location_id}` where `location_id` refers to a GCP region.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "description": "Idempotent request UUID.",
+                      "location": "query",
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+parent}/clusters",
+                  "request": {
+                    "$ref": "#/schemas/Cluster"
+                  },
+                  "response": {
+                    "$ref": "#/schemas/Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "delete": {
+                  "description": "Deletes a specific Redis cluster. Cluster stops serving and data is deleted.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/clusters/{clustersId}",
+                  "httpMethod": "DELETE",
+                  "id": "redis.projects.locations.clusters.delete",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "Required. Redis cluster resource name using the form: `projects/{project_id}/locations/{location_id}/clusters/{cluster_id}` where `location_id` refers to a GCP region.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/clusters/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "description": "Idempotent request UUID.",
+                      "location": "query",
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "#/schemas/Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "get": {
+                  "description": "Gets the details of a specific Redis cluster.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/clusters/{clustersId}",
+                  "httpMethod": "GET",
+                  "id": "redis.projects.locations.clusters.get",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "Required. Redis cluster resource name using the form: `projects/{project_id}/locations/{location_id}/clusters/{cluster_id}` where `location_id` refers to a GCP region.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/clusters/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+name}",
+                  "response": {
+                    "$ref": "#/schemas/Cluster"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "getCertificateAuthority": {
+                  "description": "Gets the details of certificate authority information for Redis cluster.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/clusters/{clustersId}/certificateAuthority",
+                  "httpMethod": "GET",
+                  "id": "redis.projects.locations.clusters.getCertificateAuthority",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "Required. Redis cluster certificate authority resource name using the form: `projects/{project_id}/locations/{location_id}/clusters/{cluster_id}/certificateAuthority` where `location_id` refers to a GCP region.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/clusters/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+name}/certificateAuthority",
+                  "response": {
+                    "$ref": "#/schemas/CertificateAuthority"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "list": {
+                  "description": "Lists all Redis clusters owned by a project in either the specified location (region) or all locations. The location should have the following format: * `projects/{project_id}/locations/{location_id}` If `location_id` is specified as `-` (wildcard), then all regions available to the project are queried, and the results are aggregated.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/clusters",
+                  "httpMethod": "GET",
+                  "id": "redis.projects.locations.clusters.list",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "parameters": {
+                    "pageSize": {
+                      "description": "The maximum number of items to return. If not specified, a default value of 1000 will be used by the service. Regardless of the page_size value, the response may include a partial list and a caller should only rely on response's `next_page_token` to determine if there are more clusters left to be queried.",
+                      "format": "int32",
+                      "location": "query",
+                      "type": "integer"
+                    },
+                    "pageToken": {
+                      "description": "The `next_page_token` value returned from a previous ListClusters request, if any.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "parent": {
+                      "description": "Required. The resource name of the cluster location using the form: `projects/{project_id}/locations/{location_id}` where `location_id` refers to a GCP region.",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+parent}/clusters",
+                  "response": {
+                    "$ref": "#/schemas/ListClustersResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                },
+                "patch": {
+                  "description": "Updates the metadata and configuration of a specific Redis cluster. Completed longrunning.Operation will contain the new cluster object in the response field. The returned operation is automatically deleted after a few hours, so there is no need to call DeleteOperation.",
+                  "flatPath": "v1/projects/{projectsId}/locations/{locationsId}/clusters/{clustersId}",
+                  "httpMethod": "PATCH",
+                  "id": "redis.projects.locations.clusters.patch",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "Required. Unique name of the resource in this scope including project and location using the form: `projects/{project_id}/locations/{location_id}/clusters/{cluster_id}`",
+                      "location": "path",
+                      "pattern": "^projects/[^/]+/locations/[^/]+/clusters/[^/]+$",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "description": "Idempotent request UUID.",
+                      "location": "query",
+                      "type": "string"
+                    },
+                    "updateMask": {
+                      "description": "Required. Mask of fields to update. At least one path must be supplied in this field. The elements of the repeated paths field may only include these fields from Cluster: * `size_gb` * `replica_count`",
+                      "format": "google-fieldmask",
+                      "location": "query",
+                      "type": "string"
+                    }
+                  },
+                  "path": "v1/{+name}",
+                  "request": {
+                    "$ref": "#/schemas/Cluster"
+                  },
+                  "response": {
+                    "$ref": "#/schemas/Operation"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform"
+                  ]
+                }
+              }
+            },
             "instances": {
               "methods": {
                 "create": {
@@ -624,9 +821,172 @@
       }
     }
   },
-  "revision": "20230912",
+  "revision": "20231017",
   "rootUrl": "https://redis.googleapis.com/",
   "schemas": {
+    "CertChain": {
+      "id": "CertChain",
+      "properties": {
+        "certificates": {
+          "description": "The certificates that form the CA chain, from leaf to root order.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "CertificateAuthority": {
+      "description": "Redis cluster certificate authority",
+      "id": "CertificateAuthority",
+      "properties": {
+        "managedServerCa": {
+          "$ref": "#/schemas/ManagedCertificateAuthority"
+        },
+        "name": {
+          "description": "Identifier. Unique name of the resource in this scope including project, location and cluster using the form: `projects/{project}/locations/{location}/clusters/{cluster}/certificateAuthority`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Cluster": {
+      "description": "A cluster instance.",
+      "id": "Cluster",
+      "properties": {
+        "authorizationMode": {
+          "description": "Optional. The authorization mode of the Redis cluster. If not provided, auth feature is disabled for the cluster.",
+          "enum": [
+            "AUTH_MODE_UNSPECIFIED",
+            "AUTH_MODE_IAM_AUTH",
+            "AUTH_MODE_DISABLED"
+          ],
+          "enumDescriptions": [
+            "Not set.",
+            "IAM basic authorization mode",
+            "Authorization disabled mode"
+          ],
+          "type": "string"
+        },
+        "createTime": {
+          "description": "Output only. The timestamp associated with the cluster creation request.",
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string"
+        },
+        "discoveryEndpoints": {
+          "description": "Output only. Endpoints created on each given network, for Redis clients to connect to the cluster. Currently only one discovery endpoint is supported.",
+          "items": {
+            "$ref": "#/schemas/DiscoveryEndpoint"
+          },
+          "readOnly": true,
+          "type": "array"
+        },
+        "name": {
+          "description": "Required. Unique name of the resource in this scope including project and location using the form: `projects/{project_id}/locations/{location_id}/clusters/{cluster_id}`",
+          "type": "string"
+        },
+        "pscConfigs": {
+          "description": "Required. Each PscConfig configures the consumer network where IPs will be designated to the cluster for client access through Private Service Connect Automation. Currently, only one PscConfig is supported.",
+          "items": {
+            "$ref": "#/schemas/PscConfig"
+          },
+          "type": "array"
+        },
+        "pscConnections": {
+          "description": "Output only. PSC connections for discovery of the cluster topology and accessing the cluster.",
+          "items": {
+            "$ref": "#/schemas/PscConnection"
+          },
+          "readOnly": true,
+          "type": "array"
+        },
+        "replicaCount": {
+          "description": "Optional. The number of replica nodes per shard.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "shardCount": {
+          "description": "Required. Number of shards for the Redis cluster.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "sizeGb": {
+          "description": "Output only. Redis memory size in GB for the entire cluster.",
+          "format": "int32",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "state": {
+          "description": "Output only. The current state of this cluster. Can be CREATING, READY, UPDATING, DELETING and SUSPENDED",
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "CREATING",
+            "ACTIVE",
+            "UPDATING",
+            "DELETING"
+          ],
+          "enumDescriptions": [
+            "Not set.",
+            "Redis cluster is being created.",
+            "Redis cluster has been created and is fully usable.",
+            "Redis cluster configuration is being updated.",
+            "Redis cluster is being deleted."
+          ],
+          "readOnly": true,
+          "type": "string"
+        },
+        "stateInfo": {
+          "$ref": "#/schemas/StateInfo",
+          "description": "Output only. Additional information about the current state of the cluster.",
+          "readOnly": true
+        },
+        "transitEncryptionMode": {
+          "description": "Optional. The in-transit encryption for the Redis cluster. If not provided, encryption is disabled for the cluster.",
+          "enum": [
+            "TRANSIT_ENCRYPTION_MODE_UNSPECIFIED",
+            "TRANSIT_ENCRYPTION_MODE_DISABLED",
+            "TRANSIT_ENCRYPTION_MODE_SERVER_AUTHENTICATION"
+          ],
+          "enumDescriptions": [
+            "In-transit encryption not set.",
+            "In-transit encryption disabled.",
+            "Use server managed encryption for in-transit encryption."
+          ],
+          "type": "string"
+        },
+        "uid": {
+          "description": "Output only. System assigned, unique identifier for the cluster.",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DiscoveryEndpoint": {
+      "description": "Endpoints on each network, for Redis clients to connect to the cluster.",
+      "id": "DiscoveryEndpoint",
+      "properties": {
+        "address": {
+          "description": "Output only. Address of the exposed Redis endpoint used by clients to connect to the service. The address could be either IP or hostname.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "port": {
+          "description": "Output only. The port number of the exposed Redis endpoint.",
+          "format": "int32",
+          "readOnly": true,
+          "type": "integer"
+        },
+        "pscConfig": {
+          "$ref": "#/schemas/PscConfig",
+          "description": "Output only. Customer configuration for where the endpoint is created and accessed from.",
+          "readOnly": true
+        }
+      },
+      "type": "object"
+    },
     "Empty": {
       "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
       "id": "Empty",
@@ -1030,6 +1390,31 @@
       },
       "type": "object"
     },
+    "ListClustersResponse": {
+      "description": "Response for ListClusters.",
+      "id": "ListClustersResponse",
+      "properties": {
+        "clusters": {
+          "description": "A list of Redis clusters in the project in the specified location, or across all locations. If the `location_id` in the parent field of the request is \"-\", all regions available to the project are queried, and the results aggregated. If in such an aggregated query a location is unavailable, a placeholder Redis entry is included in the response with the `name` field set to a value of the form `projects/{project_id}/locations/{location_id}/clusters/`- and the `status` field set to ERROR and `status_message` field set to \"location not available for ListClusters\".",
+          "items": {
+            "$ref": "#/schemas/Cluster"
+          },
+          "type": "array"
+        },
+        "nextPageToken": {
+          "description": "Token to retrieve the next page of results, or empty if there are no more results in the list.",
+          "type": "string"
+        },
+        "unreachable": {
+          "description": "Locations that could not be reached.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "ListInstancesResponse": {
       "description": "Response for ListInstances.",
       "id": "ListInstancesResponse",
@@ -1185,6 +1570,19 @@
       },
       "type": "object"
     },
+    "ManagedCertificateAuthority": {
+      "id": "ManagedCertificateAuthority",
+      "properties": {
+        "caCerts": {
+          "description": "The PEM encoded CA certificate chains for redis managed server authentication",
+          "items": {
+            "$ref": "#/schemas/CertChain"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "NodeInfo": {
       "description": "Node specific properties.",
       "id": "NodeInfo",
@@ -1233,6 +1631,50 @@
           },
           "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
           "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "OperationMetadata": {
+      "description": "Pre-defined metadata fields.",
+      "id": "OperationMetadata",
+      "properties": {
+        "apiVersion": {
+          "description": "Output only. API version used to start the operation.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "createTime": {
+          "description": "Output only. The time the operation was created.",
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string"
+        },
+        "endTime": {
+          "description": "Output only. The time the operation finished running.",
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string"
+        },
+        "requestedCancellation": {
+          "description": "Output only. Identifies whether the user has requested cancellation of the operation. Operations that have successfully been cancelled have Operation.error value with a google.rpc.Status.code of 1, corresponding to `Code.CANCELLED`.",
+          "readOnly": true,
+          "type": "boolean"
+        },
+        "statusMessage": {
+          "description": "Output only. Human-readable status of the operation, if any.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "target": {
+          "description": "Output only. Server-defined resource path for the target of the operation.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "verb": {
+          "description": "Output only. Name of the verb executed by the operation.",
+          "readOnly": true,
+          "type": "string"
         }
       },
       "type": "object"
@@ -1298,6 +1740,47 @@
       },
       "type": "object"
     },
+    "PscConfig": {
+      "id": "PscConfig",
+      "properties": {
+        "network": {
+          "description": "Required. The network where the IP address of the discovery endpoint will be reserved, in the form of projects/{network_project}/global/networks/{network_id}.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "PscConnection": {
+      "description": "Details of consumer resources in a PSC connection.",
+      "id": "PscConnection",
+      "properties": {
+        "address": {
+          "description": "Output only. The IP allocated on the consumer network for the PSC forwarding rule.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "forwardingRule": {
+          "description": "Output only. The URI of the consumer side forwarding rule. Example: projects/{projectNumOrId}/regions/us-east1/forwardingRules/{resourceId}.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "network": {
+          "description": "The consumer network where the IP address resides, in the form of projects/{project_id}/global/networks/{network_id}.",
+          "type": "string"
+        },
+        "projectId": {
+          "description": "Output only. The consumer project_id where the forwarding rule is created from.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "pscConnectionId": {
+          "description": "Output only. The PSC connection id of the forwarding rule connected to the service attachment.",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "ReconciliationOperationMetadata": {
       "description": "Operation metadata returned by the CLH during resource state reconciliation.",
       "id": "ReconciliationOperationMetadata",
@@ -1353,6 +1836,17 @@
           "description": "Optional. Timestamp when the maintenance shall be rescheduled to if reschedule_type=SPECIFIC_TIME, in RFC 3339 format, for example `2012-11-15T16:19:00.094Z`.",
           "format": "google-datetime",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "StateInfo": {
+      "description": "Represents additional information about the state of the cluster.",
+      "id": "StateInfo",
+      "properties": {
+        "updateInfo": {
+          "$ref": "#/schemas/UpdateInfo",
+          "description": "Describes ongoing update on the cluster when cluster state is UPDATING."
         }
       },
       "type": "object"
@@ -1438,6 +1932,23 @@
         "sha1Fingerprint": {
           "description": "Sha1 Fingerprint of the certificate.",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UpdateInfo": {
+      "description": "Represents information about an updating cluster.",
+      "id": "UpdateInfo",
+      "properties": {
+        "targetReplicaCount": {
+          "description": "Target number of replica nodes per shard.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "targetShardCount": {
+          "description": "Target number of shards for redis cluster",
+          "format": "int32",
+          "type": "integer"
         }
       },
       "type": "object"

--- a/utils/schema/references/run.v2.json
+++ b/utils/schema/references/run.v2.json
@@ -417,7 +417,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required. The name of the Execution to cancel. Format: projects/{project}/locations/{location}/jobs/{job}/executions/{execution}, where {project} can be project id or number.",
+                          "description": "Required. The name of the Execution to cancel. Format: `projects/{project}/locations/{location}/jobs/{job}/executions/{execution}`, where `{project}` can be project id or number.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/jobs/[^/]+/executions/[^/]+$",
                           "required": true,
@@ -450,7 +450,7 @@
                           "type": "string"
                         },
                         "name": {
-                          "description": "Required. The name of the Execution to delete. Format: projects/{project}/locations/{location}/jobs/{job}/executions/{execution}, where {project} can be project id or number.",
+                          "description": "Required. The name of the Execution to delete. Format: `projects/{project}/locations/{location}/jobs/{job}/executions/{execution}`, where `{project}` can be project id or number.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/jobs/[^/]+/executions/[^/]+$",
                           "required": true,
@@ -480,7 +480,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required. The full name of the Execution. Format: projects/{project}/locations/{location}/jobs/{job}/executions/{execution}, where {project} can be project id or number.",
+                          "description": "Required. The full name of the Execution. Format: `projects/{project}/locations/{location}/jobs/{job}/executions/{execution}`, where `{project}` can be project id or number.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/jobs/[^/]+/executions/[^/]+$",
                           "required": true,
@@ -516,7 +516,7 @@
                           "type": "string"
                         },
                         "parent": {
-                          "description": "Required. The Execution from which the Executions should be listed. To list all Executions across Jobs, use \"-\" instead of Job name. Format: projects/{project}/locations/{location}/jobs/{job}, where {project} can be project id or number.",
+                          "description": "Required. The Execution from which the Executions should be listed. To list all Executions across Jobs, use \"-\" instead of Job name. Format: `projects/{project}/locations/{location}/jobs/{job}`, where `{project}` can be project id or number.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/jobs/[^/]+$",
                           "required": true,
@@ -1115,7 +1115,7 @@
       }
     }
   },
-  "revision": "20230910",
+  "revision": "20231015",
   "rootUrl": "https://run.googleapis.com/",
   "schemas": {
     "GoogleCloudRunV2BinaryAuthorization": {
@@ -1381,6 +1381,35 @@
       },
       "type": "object"
     },
+    "GoogleCloudRunV2ContainerOverride": {
+      "description": "Per-container override specification.",
+      "id": "GoogleCloudRunV2ContainerOverride",
+      "properties": {
+        "args": {
+          "description": "Optional. Arguments to the entrypoint. Will replace existing args for override.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "clearArgs": {
+          "description": "Optional. True if the intention is to clear out existing args list.",
+          "type": "boolean"
+        },
+        "env": {
+          "description": "List of environment variables to set in the container. Will be merged with existing env for override.",
+          "items": {
+            "$ref": "#/schemas/GoogleCloudRunV2EnvVar"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The name of the container specified as a DNS_LABEL.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "GoogleCloudRunV2ContainerPort": {
       "description": "ContainerPort represents a network port in a single container.",
       "id": "GoogleCloudRunV2ContainerPort",
@@ -1425,7 +1454,7 @@
       "id": "GoogleCloudRunV2EnvVar",
       "properties": {
         "name": {
-          "description": "Required. Name of the environment variable. Must be a C_IDENTIFIER, and must not exceed 32768 characters.",
+          "description": "Required. Name of the environment variable. Must not exceed 32768 characters.",
           "type": "string"
         },
         "value": {
@@ -1991,23 +2020,47 @@
       "type": "object"
     },
     "GoogleCloudRunV2NetworkInterface": {
-      "description": "VPC network settings.",
+      "description": "Direct VPC egress settings.",
       "id": "GoogleCloudRunV2NetworkInterface",
       "properties": {
         "network": {
-          "description": "The VPC network name to access to. Defaults to \"default\" network.",
+          "description": "The VPC network that the Cloud Run resource will be able to send traffic to. At least one of network or subnetwork must be specified. If both network and subnetwork are specified, the given VPC subnetwork must belong to the given VPC network. If network is not specified, it will be looked up from the subnetwork.",
           "type": "string"
         },
         "subnetwork": {
-          "description": "The VPC subnetwork name to access to. Defaults to the same vaule of network.",
+          "description": "The VPC subnetwork that the Cloud Run resource will get IPs from. At least one of network or subnetwork must be specified. If both network and subnetwork are specified, the given VPC subnetwork must belong to the given VPC network. If subnetwork is not specified, the subnetwork with the same name with the network will be used.",
           "type": "string"
         },
         "tags": {
-          "description": "Network tags applied to this VPC network.",
+          "description": "Network tags applied to this Cloud Run resource.",
           "items": {
             "type": "string"
           },
           "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "GoogleCloudRunV2Overrides": {
+      "description": "RunJob Overrides that contains Execution fields to be overridden.",
+      "id": "GoogleCloudRunV2Overrides",
+      "properties": {
+        "containerOverrides": {
+          "description": "Per container override specification.",
+          "items": {
+            "$ref": "#/schemas/GoogleCloudRunV2ContainerOverride"
+          },
+          "type": "array"
+        },
+        "taskCount": {
+          "description": "Optional. The desired number of tasks the execution should run. Will replace existing task_count value.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "timeout": {
+          "description": "Duration in seconds the task may be active before the system will actively try to mark it failed and kill associated containers. Will replace existing timeout_seconds value.",
+          "format": "google-duration",
+          "type": "string"
         }
       },
       "type": "object"
@@ -2233,6 +2286,11 @@
           "$ref": "#/schemas/GoogleCloudRunV2RevisionScaling",
           "description": "Scaling settings for this revision."
         },
+        "scalingStatus": {
+          "$ref": "#/schemas/GoogleCloudRunV2RevisionScalingStatus",
+          "description": "Output only. The current effective scaling settings for the revision.",
+          "readOnly": true
+        },
         "service": {
           "description": "Output only. The name of the parent service.",
           "readOnly": true,
@@ -2287,6 +2345,18 @@
         },
         "minInstanceCount": {
           "description": "Minimum number of serving instances that this resource should have.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "GoogleCloudRunV2RevisionScalingStatus": {
+      "description": "Effective settings for the current revision",
+      "id": "GoogleCloudRunV2RevisionScalingStatus",
+      "properties": {
+        "desiredMinInstanceCount": {
+          "description": "The current number of min instances provisioned for this revision.",
           "format": "int32",
           "type": "integer"
         }
@@ -2383,6 +2453,10 @@
         "etag": {
           "description": "A system-generated fingerprint for this version of the resource. May be used to detect modification conflict during updates.",
           "type": "string"
+        },
+        "overrides": {
+          "$ref": "#/schemas/GoogleCloudRunV2Overrides",
+          "description": "Overrides specification for a given execution of a job. If provided, overrides will be applied to update the execution or task spec."
         },
         "validateOnly": {
           "description": "Indicates that the request should be validated without actually deleting any resources.",
@@ -2611,11 +2685,6 @@
           "readOnly": true,
           "type": "array"
         },
-        "trafficTagsCleanupThreshold": {
-          "description": "Optional. Override the traffic tag threshold limit. Garbage collection will start cleaning up non-serving tagged traffic targets based on creation item. The default value is 2000.",
-          "format": "int64",
-          "type": "string"
-        },
         "uid": {
           "description": "Output only. Server assigned unique identifier for the trigger. The value is a UUID4 string and guaranteed to remain unchanged until the resource is deleted.",
           "readOnly": true,
@@ -2793,6 +2862,12 @@
           "description": "Output only. Reserved for future use.",
           "readOnly": true,
           "type": "boolean"
+        },
+        "scheduledTime": {
+          "description": "Output only. Represents time when the task was scheduled to run by the system. It is not guaranteed to be set in happens-before order across separate operations.",
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string"
         },
         "serviceAccount": {
           "description": "Email address of the IAM service account associated with the Task of a Job. The service account represents the identity of the running task, and determines what permissions the task has. If not provided, the task will use the project's default service account.",
@@ -3041,11 +3116,11 @@
       "type": "object"
     },
     "GoogleCloudRunV2VpcAccess": {
-      "description": "VPC Access settings. For more information on creating a VPC Connector, visit https://cloud.google.com/vpc/docs/configure-serverless-vpc-access For information on how to configure Cloud Run with an existing VPC Connector, visit https://cloud.google.com/run/docs/configuring/connecting-vpc",
+      "description": "VPC Access settings. For more information on sending traffic to a VPC network, visit https://cloud.google.com/run/docs/configuring/connecting-vpc.",
       "id": "GoogleCloudRunV2VpcAccess",
       "properties": {
         "connector": {
-          "description": "VPC Access connector name. Format: projects/{project}/locations/{location}/connectors/{connector}, where {project} can be project id or number.",
+          "description": "VPC Access connector name. Format: projects/{project}/locations/{location}/connectors/{connector}, where {project} can be project id or number. For more information on sending traffic to a VPC network via a connector, visit https://cloud.google.com/run/docs/configuring/vpc-connectors.",
           "type": "string"
         },
         "egress": {
@@ -3063,7 +3138,7 @@
           "type": "string"
         },
         "networkInterfaces": {
-          "description": "VPC network to access to. Currently only single network interface is supported.",
+          "description": "Direct VPC egress settings. Currently only single network interface is supported.",
           "items": {
             "$ref": "#/schemas/GoogleCloudRunV2NetworkInterface"
           },

--- a/utils/schema/references/vpcaccess.v1.json
+++ b/utils/schema/references/vpcaccess.v1.json
@@ -384,7 +384,7 @@
       }
     }
   },
-  "revision": "20230914",
+  "revision": "20231016",
   "rootUrl": "https://vpcaccess.googleapis.com/",
   "schemas": {
     "Connector": {


### PR DESCRIPTION
- json schema was missing the `cloudrun` key that maps to https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services#Service

- script that builds the json schema also updates API definitions to latest.