### PR TITLE
Cors allow methods and custom headers

### DIFF
--- a/docs/source/topics.rst
+++ b/docs/source/topics.rst
@@ -778,11 +778,11 @@ Cors can be set on the route level or on the Goblet application level. Setting `
     def home():
         return "cors headers"
 
-Use the `CORSConfig` class to set customized cors headers from the `goblet.resources.routes` class. 
+Use the `CORSConfig` class to set customized cors headers from the `goblet.handlers.routes` class. 
 
 .. code:: python 
 
-    from goblet.resources.routes import CORSConfig
+    from goblet.handlers.routes import CORSConfig
 
     @app.route('/custom_cors', cors=CORSConfig(allow_origin='localhost'))
     def custom_cors():

--- a/examples/example_bq_spark_stored_procedure/additional.py
+++ b/examples/example_bq_spark_stored_procedure/additional.py
@@ -1,6 +1,8 @@
 import logging
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
 
 def additional_func():
     logger.info("additional_func")

--- a/examples/example_bq_spark_stored_procedure/main.py
+++ b/examples/example_bq_spark_stored_procedure/main.py
@@ -1,5 +1,6 @@
 import logging
 from goblet import Goblet, goblet_entrypoint
+
 # from spark import spark_handler
 
 app = Goblet(function_name="create-bq-spark-stored-procedure")

--- a/examples/example_bq_spark_stored_procedure/spark.py
+++ b/examples/example_bq_spark_stored_procedure/spark.py
@@ -1,12 +1,11 @@
 def spark_handler():
     from pyspark.sql import SparkSession
     import pyspark.sql.functions as F
+
     spark = SparkSession.builder.appName("spark-bigquery-demo").getOrCreate()
 
     # Load data from BigQuery.
-    texts = spark.read.format("bigquery") \
-    .option("table", "tutorial.poc") \
-    .load()
+    texts = spark.read.format("bigquery").option("table", "tutorial.poc").load()
     texts.createOrReplaceTempView("words")
 
     # Perform word count.
@@ -15,9 +14,10 @@ def spark_handler():
     text_count.printSchema()
 
     # Saving the data to BigQuery
-    text_count.write.mode("append").format("bigquery") \
-    .option("writeMethod", "direct") \
-    .save("tutorial.wordcount_output")
+    text_count.write.mode("append").format("bigquery").option(
+        "writeMethod", "direct"
+    ).save("tutorial.wordcount_output")
+
 
 if __name__ == "__main__":
     spark_handler()

--- a/examples/main.py
+++ b/examples/main.py
@@ -5,6 +5,7 @@ from goblet.infrastructures.alerts import (
     LogMatchCondition,
     CustomMetricCondition,
 )
+from goblet.handlers.routes import CORSConfig
 import asyncio
 import logging
 
@@ -173,6 +174,12 @@ def response():
         {"failed": 400}, headers={"Content-Type": "application/json"}, status_code=400
     )
 
+
+# Example CORS
+
+@app.route('/custom_cors', cors=CORSConfig(allow_origin='localhost', allow_methods=["GET"], extra_headers={"X-TEST":"X-HEADER-VALUE"}))
+def custom_cors():
+    return jsonify('localhost is allowed with GET method')
 
 # Scheduled job
 @app.schedule("5 * * * *")

--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 12, 5)
+VERSION = (0, 12, 6)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -507,10 +507,10 @@ class CORSConfig(object):
             headers.update({"Access-Control-Allow-Credentials": "true"})
         if self._allow_methods:
             headers.update(
-                {"Access-Control-Allow-Methods": ",".join(self._expose_headers)}
+                {"Access-Control-Allow-Methods": ",".join(self._allow_methods)}
             )
         if self._extra_headers:
-            headers.update(self._expose_headers)
+            headers.update(self._extra_headers)
 
         return headers
 

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -465,9 +465,11 @@ class CORSConfig(object):
         self,
         allow_origin="*",
         allow_headers=None,
+        allow_methods=None,
         expose_headers=None,
         max_age=None,
         allow_credentials=None,
+        extra_headers=None,
     ):
         self.allow_origin = allow_origin
 
@@ -483,6 +485,8 @@ class CORSConfig(object):
 
         self._max_age = max_age
         self._allow_credentials = allow_credentials
+        self._allow_methods = allow_methods
+        self._extra_headers = extra_headers
 
     @property
     def allow_headers(self):
@@ -501,6 +505,12 @@ class CORSConfig(object):
             headers.update({"Access-Control-Max-Age": str(self._max_age)})
         if self._allow_credentials is True:
             headers.update({"Access-Control-Allow-Credentials": "true"})
+        if self._allow_methods:
+            headers.update(
+                {"Access-Control-Allow-Methods": ",".join(self._expose_headers)}
+            )
+        if self._extra_headers:
+            headers.update(self._expose_headers)
 
         return headers
 

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -138,7 +138,14 @@ class TestRoutes:
         def mock_function_override():
             return Response("200")
 
-        @app.route("/test3", cors=CORSConfig(allow_origin="localhost"))
+        @app.route(
+            "/test3",
+            cors=CORSConfig(
+                allow_origin="localhost",
+                allow_methods=["GET", "PUT"],
+                extra_headers={"X-TEST": "X-VALUE"},
+            ),
+        )
         def mock_function3():
             return jsonify("200")
 
@@ -173,6 +180,8 @@ class TestRoutes:
         mock_event3.json = {}
         resp3 = app(mock_event3, None)
         assert resp3[2]["Access-Control-Allow-Origin"] == "localhost"
+        assert resp3[2]["Access-Control-Allow-Methods"] == "GET,PUT"
+        assert resp3[2]["X-TEST"] == "X-VALUE"
 
     def test_cors_options(self):
         app = Goblet(function_name="goblet_cors")


### PR DESCRIPTION
closes #469 

```
@app.route('/custom_cors', cors=CORSConfig(allow_origin='localhost', allow_methods=["GET"], extra_headers={"X-TEST":"X-HEADER-VALUE"}))
def custom_cors():
    return jsonify('localhost is allowed with GET method')
```