### PR TITLE
Cloud run jobs specifying an environment via app.stage() with schedule decorator still deploy cloud scheduler to all envs

### DIFF
--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -259,13 +259,14 @@ class Goblet_Decorators:
             registration_kwargs={"headers": headers},
         )
 
-    def job(self, name, task_id=0, schedule=None, timezone="UTC", **kwargs):
+    def job(self, name, task_id=0, schedule=None, timezone="UTC", stage="", stages=[], **kwargs):
         """Cloudrun Job"""
+
         if schedule and task_id != 0:
             raise ValueError("Schedule can only be added to task_id with value 0")
         if kwargs and task_id != 0:
             raise ValueError("Arguments can only be added to task_id with value 0")
-        if schedule:
+        if schedule and (os.getenv("STAGE") == stage or os.getenv("STAGE") in stages):
             self._register_handler(
                 "schedule",
                 f"schedule-job-{name}",

--- a/goblet/decorators.py
+++ b/goblet/decorators.py
@@ -259,14 +259,27 @@ class Goblet_Decorators:
             registration_kwargs={"headers": headers},
         )
 
-    def job(self, name, task_id=0, schedule=None, timezone="UTC", stage="", stages=[], **kwargs):
+    def job(
+        self,
+        name,
+        task_id=0,
+        schedule=None,
+        timezone="UTC",
+        stage=None,
+        stages=[],
+        **kwargs,
+    ):
         """Cloudrun Job"""
 
         if schedule and task_id != 0:
             raise ValueError("Schedule can only be added to task_id with value 0")
         if kwargs and task_id != 0:
             raise ValueError("Arguments can only be added to task_id with value 0")
-        if schedule and (os.getenv("STAGE") == stage or os.getenv("STAGE") in stages):
+
+        if schedule and (
+            (not stage and not stages)
+            or (os.getenv("STAGE") == stage or os.getenv("STAGE") in stages)
+        ):
             self._register_handler(
                 "schedule",
                 f"schedule-job-{name}",

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -231,18 +231,18 @@ class TestDecoraters:
 
         app = Goblet("test", backend="cloudrun", config={"stages": {"TEST": {}}})
 
-        @app.job("testjob1", schedule="* * * * *", stage="TEST")
         @app.stage("TEST")
+        @app.job("testjob1", schedule="* * * * *")
         def dummy_function():
             return "test"
 
-        @app.job("testjob2", schedule="* * * * *", stage="TEST2")
         @app.stage("TEST2")
+        @app.job("testjob2", schedule="* * * * *")
         def dummy_function2():
             return "test"
 
-        @app.job("testjob3", schedule="* * * * *", stages=["TEST", "TEST2"])
         @app.stage(stages=["TEST", "TEST2"])
+        @app.job("testjob3", schedule="* * * * *")
         def dummy_function3():
             return "test"
 

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -232,17 +232,17 @@ class TestDecoraters:
         app = Goblet("test", backend="cloudrun", config={"stages": {"TEST": {}}})
 
         @app.stage("TEST")
-        @app.job("testjob1", schedule="* * * * *")
+        @app.job("testjob1", schedule="* * * * *", stage="TEST")
         def dummy_function():
             return "test"
 
         @app.stage("TEST2")
-        @app.job("testjob2", schedule="* * * * *")
+        @app.job("testjob2", schedule="* * * * *", stage="TEST2")
         def dummy_function2():
             return "test"
 
         @app.stage(stages=["TEST", "TEST2"])
-        @app.job("testjob3", schedule="* * * * *")
+        @app.job("testjob3", schedule="* * * * *", stages=["TEST", "TEST2"])
         def dummy_function3():
             return "test"
 

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -226,6 +226,31 @@ class TestDecoraters:
 
         assert len(app.handlers["route"].resources) == 2
 
+    def test_stages_with_schedule(self, monkeypatch):
+        monkeypatch.setenv("STAGE", "TEST")
+
+        app = Goblet("test", backend="cloudrun", config={"stages": {"TEST": {}}})
+
+        @app.job("testjob1", schedule="* * * * *", stage="TEST")
+        @app.stage("TEST")
+        def dummy_function():
+            return "test"
+
+        @app.job("testjob2", schedule="* * * * *", stage="TEST2")
+        @app.stage("TEST2")
+        def dummy_function2():
+            return "test"
+
+        @app.job("testjob3", schedule="* * * * *", stages=["TEST", "TEST2"])
+        @app.stage(stages=["TEST", "TEST2"])
+        def dummy_function3():
+            return "test"
+
+        assert list(app.handlers["schedule"].resources.keys()) == [
+            "schedule-job-testjob1",
+            "schedule-job-testjob3"
+        ]
+
     def test_errorhandler_default(self):
         app = Goblet("test")
 

--- a/goblet/tests/test_app.py
+++ b/goblet/tests/test_app.py
@@ -226,7 +226,7 @@ class TestDecoraters:
 
         assert len(app.handlers["route"].resources) == 2
 
-    def test_stages_with_schedule(self, monkeypatch):
+    def test_schedule_with_stages(self, monkeypatch):
         monkeypatch.setenv("STAGE", "TEST")
 
         app = Goblet("test", backend="cloudrun", config={"stages": {"TEST": {}}})
@@ -248,7 +248,20 @@ class TestDecoraters:
 
         assert list(app.handlers["schedule"].resources.keys()) == [
             "schedule-job-testjob1",
-            "schedule-job-testjob3"
+            "schedule-job-testjob3",
+        ]
+
+    def test_schedule_without_stages(self, monkeypatch):
+        monkeypatch.setenv("STAGE", "TEST")
+
+        app = Goblet("test", backend="cloudrun", config={"stages": {"TEST": {}}})
+
+        @app.job("testjob1", schedule="* * * * *")
+        def dummy_function():
+            return "test"
+
+        assert list(app.handlers["schedule"].resources.keys()) == [
+            "schedule-job-testjob1"
         ]
 
     def test_errorhandler_default(self):


### PR DESCRIPTION
See https://github.com/goblet/goblet/issues/481