### PR TITLE
Register nested handlers correctly

### DIFF
--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 13, 0)
+VERSION = (0, 13, 1)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/utils/schema/build.py
+++ b/utils/schema/build.py
@@ -11,7 +11,7 @@ def get_references(d):
         if isinstance(v, dict):
             get_references(v)
         else:
-            if k == "$ref" and v.startswith("https://") and 'googleapis.com' in v:
+            if k == "$ref" and v.startswith("https://") and "googleapis.com" in v:
                 references.add(v.split("#")[0])
 
 


### PR DESCRIPTION
* Register nested handlers at the same time as the main handler to all registration to work with the stages decorator. (closes #481)

The following will now register the scheduler and job at the same time correctly. 
```
@app.job("testjob2", schedule="* * * * *")
@app.stage(stages=["TEST"])
def test_cloudrun_job2(id):
    run_job()
```