### PR TITLE
Bugfix 483 - custom files include

### DIFF
--- a/goblet/__version__.py
+++ b/goblet/__version__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 13, 1)
+VERSION = (0, 13, 2)
 
 
 __version__ = ".".join(map(str, VERSION))

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -213,7 +213,7 @@ class Backend:
         for pattern in self.zip_config.get("include", []):
             globbed_files.extend(Path("").rglob(pattern))
         for path in globbed_files:
-            if not set(path.parts).intersection(exclusion_set):
+            if not set(path.parts).intersection(exclusion_set) and str(path) != '.goblet/config.json':
                 self.log.debug(f"Zipping file: {path}...")
                 self.zipf.write(str(path))
 

--- a/goblet/backends/backend.py
+++ b/goblet/backends/backend.py
@@ -213,7 +213,10 @@ class Backend:
         for pattern in self.zip_config.get("include", []):
             globbed_files.extend(Path("").rglob(pattern))
         for path in globbed_files:
-            if not set(path.parts).intersection(exclusion_set) and str(path) != '.goblet/config.json':
+            if (
+                not set(path.parts).intersection(exclusion_set)
+                and str(path) != ".goblet/config.json"
+            ):
                 self.log.debug(f"Zipping file: {path}...")
                 self.zipf.write(str(path))
 


### PR DESCRIPTION
This closes #483 which occurs when including `config.json` in `custom_files` , would replace config.json, which is modified by goblet behind the scenes if a  stage is specified. 