### PR TITLE
fix: add 3rd arg validation on routes with CORS enabled

### DIFF
--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -450,7 +450,15 @@ class RouteEntry:
         if isinstance(resp, goblet.Response):
             resp.headers.update(self.cors.get_access_control_headers())
         if isinstance(resp, tuple):
-            resp[2].update(self.cors.get_access_control_headers())
+            # Flask custom Tuple response: body, status code, headers ({}, 200, {})
+            if len(resp) > 2:
+                resp[2].update(self.cors.get_access_control_headers())
+            else:
+                resp = goblet.Response(
+                    resp[0],
+                    status_code=int(resp[1]) or 200, 
+                    headers=self.cors.get_access_control_headers()
+                )
         if isinstance(resp, str):
             resp = goblet.Response(resp, headers=self.cors.get_access_control_headers())
         return resp

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -456,7 +456,7 @@ class RouteEntry:
             else:
                 resp = goblet.Response(
                     resp[0],
-                    status_code=int(resp[1]) or 200, 
+                    status_code=int(resp[1]) or 200,
                     headers=self.cors.get_access_control_headers()
                 )
         if isinstance(resp, str):

--- a/goblet/handlers/routes.py
+++ b/goblet/handlers/routes.py
@@ -457,7 +457,7 @@ class RouteEntry:
                 resp = goblet.Response(
                     resp[0],
                     status_code=int(resp[1]) or 200,
-                    headers=self.cors.get_access_control_headers()
+                    headers=self.cors.get_access_control_headers(),
                 )
         if isinstance(resp, str):
             resp = goblet.Response(resp, headers=self.cors.get_access_control_headers())

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -89,7 +89,7 @@ class TestRoutes:
         mock_event1.json = {}
         resp = app(mock_event1, None)
         assert resp == ("success", 201)
-        
+
     def test_call_tuple_with_cors_response(self):
         app = Goblet(function_name="goblet_example",
                      cors=True)
@@ -106,7 +106,7 @@ class TestRoutes:
         resp = app(mock_event1, None)
         assert resp.body == "success"
         assert resp.status_code == 201
-        
+
     def test_call_tuple_with_headers_response(self):
         app = Goblet(function_name="goblet_example")
 
@@ -121,7 +121,7 @@ class TestRoutes:
         mock_event1.json = {}
         resp = app(mock_event1, None)
         assert resp == ("success", 201, {"x-header": "test"})
-    
+
     def test_call_tuple_with_cors_and_headers_response(self):
         app = Goblet(function_name="goblet_example",
                      cors=True)

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -75,6 +75,71 @@ class TestRoutes:
         assert gateway.resources["/home"]["GET"]
         assert gateway.resources["/home2"]["GET"]
 
+    def test_call_tuple_response(self):
+        app = Goblet(function_name="goblet_example")
+
+        @app.route("/test", methods=["POST"])
+        def mock_function():
+            return "success", 201
+
+        mock_event1 = Mock()
+        mock_event1.path = "/test"
+        mock_event1.method = "POST"
+        mock_event1.headers = {}
+        mock_event1.json = {}
+        resp = app(mock_event1, None)
+        assert resp == ("success", 201)
+        
+    def test_call_tuple_with_cors_response(self):
+        app = Goblet(function_name="goblet_example",
+                     cors=True)
+
+        @app.route("/test", methods=["POST"])
+        def mock_function():
+            return "success", 201
+
+        mock_event1 = Mock()
+        mock_event1.path = "/test"
+        mock_event1.method = "POST"
+        mock_event1.headers = {}
+        mock_event1.json = {}
+        resp = app(mock_event1, None)
+        assert resp.body == "success"
+        assert resp.status_code == 201
+        
+    def test_call_tuple_with_headers_response(self):
+        app = Goblet(function_name="goblet_example")
+
+        @app.route("/test", methods=["POST"])
+        def mock_function():
+            return "success", 201, {"x-header": "test"}
+
+        mock_event1 = Mock()
+        mock_event1.path = "/test"
+        mock_event1.method = "POST"
+        mock_event1.headers = {}
+        mock_event1.json = {}
+        resp = app(mock_event1, None)
+        assert resp == ("success", 201, {"x-header": "test"})
+    
+    def test_call_tuple_with_cors_and_headers_response(self):
+        app = Goblet(function_name="goblet_example",
+                     cors=True)
+
+        @app.route("/test", methods=["POST"])
+        def mock_function():
+            return "success", 201, {"x-header": "test"}
+
+        mock_event1 = Mock()
+        mock_event1.path = "/test"
+        mock_event1.method = "POST"
+        mock_event1.headers = {}
+        mock_event1.json = {}
+        resp = app(mock_event1, None)
+        assert resp[0] == "success"
+        assert resp[1] == 201
+        assert resp[2].get("x-header") == "test"
+
     def test_call_route(self):
         app = Goblet(function_name="goblet_example")
         mock = Mock()

--- a/goblet/tests/test_routes.py
+++ b/goblet/tests/test_routes.py
@@ -91,8 +91,7 @@ class TestRoutes:
         assert resp == ("success", 201)
 
     def test_call_tuple_with_cors_response(self):
-        app = Goblet(function_name="goblet_example",
-                     cors=True)
+        app = Goblet(function_name="goblet_example", cors=True)
 
         @app.route("/test", methods=["POST"])
         def mock_function():
@@ -123,8 +122,7 @@ class TestRoutes:
         assert resp == ("success", 201, {"x-header": "test"})
 
     def test_call_tuple_with_cors_and_headers_response(self):
-        app = Goblet(function_name="goblet_example",
-                     cors=True)
+        app = Goblet(function_name="goblet_example", cors=True)
 
         @app.route("/test", methods=["POST"])
         def mock_function():


### PR DESCRIPTION
This PR checks if there is missing an 3rd argument on Tuples route responses and manage it properly when CORS is enabled. (closes #490 )